### PR TITLE
Fix fetch credentials option casing

### DIFF
--- a/src/components/app/request-worker.ts
+++ b/src/components/app/request-worker.ts
@@ -52,7 +52,7 @@ export class RequestWorker {
    */
   async translationRequestHandler(e: CustomEvent<TranslationRequest>) {
     const { text, resolve, reject } = e.detail;
-    const requestOptions = {
+    const requestOptions: RequestInit = {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
@@ -60,7 +60,7 @@ export class RequestWorker {
       body: JSON.stringify({
         source: text
       }),
-      Credentials: 'include'
+      credentials: 'include'
     };
 
     // Helper function to delay execution

--- a/src/utils/api-manager.ts
+++ b/src/utils/api-manager.ts
@@ -198,9 +198,9 @@ export class APIManager {
     jmespathQuery: string;
   }): Promise<BlobJSONLPayload> => {
     // Fetch the blob
-    const requestOptions = {
+    const requestOptions: RequestInit = {
       method: 'GET',
-      Credentials: 'include'
+      credentials: 'include'
     };
 
     const queryPath = new URLSearchParams();
@@ -262,9 +262,9 @@ export class APIManager {
 
   refreshRendererList = async () => {
     // Fetch the blob
-    const requestOptions = {
+    const requestOptions: RequestInit = {
       method: 'GET',
-      Credentials: 'include'
+      credentials: 'include'
     };
 
     const response = await fetch(


### PR DESCRIPTION
## Summary
- Change the affected fetch request option objects from the ignored `Credentials` property to the standard lowercase `credentials` property.
- Add explicit `RequestInit` annotations so TypeScript validates these objects against the browser fetch API contract.
- Covers the backend JSONL fetch, renderer list refresh, and translation request paths that were intended to send credentials.

## Bug
`fetch` only reads `RequestInit.credentials`; JavaScript object keys are case-sensitive, so `Credentials: 'include'` is treated as an unrelated property and silently ignored. For cross-origin deployments this leaves the request at the browser default credentials behavior, so cookies and other credentials are not included even though the server enables credentialed CORS.

## Fix
Updated the three affected request option objects:
- `src/utils/api-manager.ts` JSONL fetch
- `src/utils/api-manager.ts` renderer list refresh
- `src/components/app/request-worker.ts` translation request

Each now uses `credentials: 'include'` and is typed as `RequestInit`, which prevents future casing or value mistakes from bypassing TypeScript.

## Verification
- Searched `src` for remaining uppercase `Credentials:` request options; none remain.
- Ran `pnpm run build` successfully.