### PR TITLE
Fix translation of string message content

### DIFF
--- a/src/components/conversation/conversation.ts
+++ b/src/components/conversation/conversation.ts
@@ -1089,17 +1089,22 @@ export class EuphonyConversation extends LitElement {
       // We only translate [text messages, developer messages]
       const contentType = getContentTypeFromContent(message.content);
       if (contentType === 'text' || contentType === 'developer') {
-        const content = [message.content[0]];
-        // Ignore the below check because ts wants us to split it into n
-        // different conditions
-        // @ts-ignore
-        const translatableMessage: TranslatableMessage = {
-          ...message,
-          content: content as
-            | TextMessageContent[]
-            | DeveloperContentMessageContent[],
-          isTranslated: false
-        };
+        // Normalize string content into a text object before translating so
+        // downstream updates mutate the translated message clone.
+        const content = getContentFromContentOrString(message.content);
+        const translatableMessage: TranslatableMessage =
+          contentType === 'text'
+            ? {
+                ...translatedMessages[i],
+                content: [content as TextMessageContent],
+                isTranslated: false
+              }
+            : {
+                ...translatedMessages[i],
+                content: [content as DeveloperContentMessageContent],
+                isTranslated: false
+              };
+        translatedMessages[i] = translatableMessage;
         promises.push(updateMessageWithTranslation(translatableMessage, i));
       }
     }


### PR DESCRIPTION
## Summary
- Normalize plain string message content into `{ text: ... }` before it enters the translation pipeline.
- Replace the corresponding entry in `translatedMessages` with the normalized translatable message so async translation responses update the translated clone.
- Remove the previous `@ts-ignore` by constructing the `TranslatableMessage` through explicit text/developer branches.

## Bug
`Message.content` can be either an array of content objects or a plain string. The translation queue previously used `message.content[0]` for every text/developer message. For plain strings, that indexes the first character, so `"Hello"` became `"H"` instead of a text content object.

That malformed shape meant translation requests were built from the wrong content and downstream logic expected object fields such as `text` on a string character.

## Fix
The translation queue now calls the existing `getContentFromContentOrString` helper, which converts string content into `{ text: fullString }` and preserves array-backed content by selecting the first content object. The normalized message is assigned back into `translatedMessages[i]` before translation starts, ensuring response handling mutates the translated clone rather than a temporary object.

## Verification
- Confirmed the problematic `message.content[0]` expression is no longer used in the translation queue.
- Ran `pnpm run build` successfully.