### PR TITLE
Preserve mode flags when updating URL

### DIFF
--- a/src/components/app/url-manager.ts
+++ b/src/components/app/url-manager.ts
@@ -46,6 +46,20 @@ export class URLManager {
       params.delete('grid');
     }
 
+    // Editor mode
+    if (this.app.isEditorMode) {
+      params.set('editor', 'true');
+    } else {
+      params.delete('editor');
+    }
+
+    // Frontend only mode
+    if (this.app.isFrontendOnlyMode) {
+      params.set('frontend-only', 'true');
+    } else {
+      params.delete('frontend-only');
+    }
+
     const paramsString = params.toString();
 
     history.pushState({}, '', `?${paramsString}${currentHash}`);


### PR DESCRIPTION
## Summary
- Preserve `editor=true` when `URLManager.updateURL()` rewrites application state into the query string.
- Preserve `frontend-only=true` the same way.
- Delete each flag when the corresponding app mode is false, matching the existing set/delete pattern for markdown, metadata, jmespath, and grid state.

## Bug
`updateConfigsFromURL()` reads `editor` and `frontend-only` query parameters to enable editor mode and frontend-only mode, but `updateURL()` did not write those parameters back out when other state changed. Any action that called `updateURL()`, such as pagination, markdown/metadata toggles, layout changes, or search, could rewrite the URL without these mode flags.

For editor mode this meant a user could remain in editor mode during the current session, but after refresh the URL no longer contained `editor=true`, so the app reopened outside editor mode.

## Fix
`updateURL()` now mirrors the read-side URL flags:
- `this.app.isEditorMode` controls `editor=true`
- `this.app.isFrontendOnlyMode` controls `frontend-only=true`

This keeps mode state stable across normal URL updates while still removing the flags when those modes are disabled.

## Verification
- Reviewed `updateConfigsFromURL()` to confirm both flags are read from the URL.
- Confirmed common app actions call `this.urlManager.updateURL()`, making the reported stripping path legitimate.
- Ran `pnpm run build` successfully.