### PR TITLE
feat(atif): add Harbor ATIF trajectory format support

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "dev": "vite --port 3000",
     "build": "tsc && vite build",
+    "test": "vitest run",
     "build:github": "tsc && VITE_EUPHONY_FRONTEND_ONLY=true vite build --mode github",
     "build:library": "tsc && vite build --mode library",
     "deploy:github": "pnpm run build:github && pnpm gh-pages -m \"Deploy $(git log '--format=format:%H' main -1)\" -d ./dist",
@@ -50,6 +51,7 @@
     "gh-pages": "^6.3.0",
     "globals": "^16.5.0",
     "globby": "^14.1.0",
+    "gpt-tokenizer": "^3.4.0",
     "jmespath": "^0.16.0",
     "lit": "^3.3.2",
     "marked": "^15.0.12",
@@ -61,7 +63,7 @@
     "vite": "^7.3.2",
     "vite-plugin-dts": "^4.5.4",
     "vite-plugin-web-components-hmr": "^0.1.3",
-    "gpt-tokenizer": "^3.4.0"
+    "vitest": "^4.1.5"
   },
   "packageManager": "pnpm@10.25.0+sha512.5e82639027af37cf832061bcc6d639c219634488e0f2baebe785028a793de7b525ffcd3f7ff574f5e9860654e098fe852ba8ac5dd5cefe1767d23a020a92f501"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       vite-plugin-web-components-hmr:
         specifier: ^0.1.3
         version: 0.1.3(vite@7.3.2(terser@5.46.1))
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(vite@7.3.2(terser@5.46.1))
 
 packages:
 
@@ -658,14 +661,23 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/d3-format@3.0.4':
     resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
 
   '@types/d3-random@3.0.3':
     resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -743,6 +755,35 @@ packages:
   '@typescript-eslint/visitor-keys@8.58.2':
     resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
@@ -825,6 +866,10 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   async-mutex@0.5.0:
     resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
@@ -871,6 +916,10 @@ packages:
 
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -968,6 +1017,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
@@ -1061,9 +1113,16 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -1383,6 +1442,9 @@ packages:
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1544,6 +1606,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -1565,6 +1630,12 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -1599,9 +1670,20 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1710,12 +1792,58 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2225,11 +2353,20 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@types/argparse@1.0.38': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/d3-format@3.0.4': {}
 
   '@types/d3-random@3.0.3': {}
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -2336,6 +2473,47 @@ snapshots:
       '@typescript-eslint/types': 8.58.2
       eslint-visitor-keys: 5.0.1
 
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@7.3.2(terser@5.46.1))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(terser@5.46.1)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@volar/language-core@2.4.28':
     dependencies:
       '@volar/source-map': 2.4.28
@@ -2429,6 +2607,8 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  assertion-error@2.0.1: {}
+
   async-mutex@0.5.0:
     dependencies:
       tslib: 2.8.1
@@ -2471,6 +2651,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001788: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -2540,6 +2722,8 @@ snapshots:
   entities@7.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.1.0: {}
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -2669,7 +2853,13 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   exsolve@1.0.8: {}
 
@@ -2969,6 +3159,8 @@ snapshots:
 
   node-releases@2.0.37: {}
 
+  obug@2.1.1: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -3128,6 +3320,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   slash@3.0.0: {}
 
   slash@5.1.0: {}
@@ -3142,6 +3336,10 @@ snapshots:
   source-map@0.6.1: {}
 
   sprintf-js@1.0.3: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   string-argv@0.3.2: {}
 
@@ -3172,10 +3370,16 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.2: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -3266,11 +3470,41 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.46.1
 
+  vitest@4.1.5(vite@7.3.2(terser@5.46.1)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@7.3.2(terser@5.46.1))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.2(terser@5.46.1)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - msw
+
   vscode-uri@3.1.0: {}
 
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -16,8 +16,10 @@ import {
   BrowserAPIManager,
   EUPHONY_API_URL
 } from '../../utils/api-manager';
+import { isAtifTrajectory } from '../../utils/atif-trajectory';
 import { isCodexSessionJSONL } from '../../utils/codex-session';
 import { updatePopperOverlay } from '../../utils/utils';
+import { EuphonyAtif } from '../atif/atif';
 import { EuphonyCodex } from '../codex/codex';
 import { NightjarConfirmDialog } from '../confirm-dialog/confirm-dialog';
 import {
@@ -52,6 +54,7 @@ import iconInfoSmall from '../../images/icon-info-circle-small.svg?raw';
 import iconLaptop from '../../images/icon-macbook.svg?raw';
 import iconSetting from '../../images/icon-settings.svg?raw';
 
+import '../atif/atif';
 import '../codex/codex';
 import '../confirm-dialog/confirm-dialog';
 import '../conversation/conversation';
@@ -74,6 +77,7 @@ export interface ToastMessage {
 enum DataType {
   CONVERSATION = 'conversation',
   CODEX = 'codex',
+  ATIF = 'atif',
   JSON = 'json'
 }
 
@@ -98,7 +102,10 @@ const TOAST_DURATIONS: Record<ToastType, number> = {
   error: 15000
 };
 
-type ConversationViewerElement = EuphonyConversation | EuphonyCodex;
+type ConversationViewerElement =
+  | EuphonyConversation
+  | EuphonyCodex
+  | EuphonyAtif;
 
 let initURL = '';
 
@@ -140,6 +147,9 @@ export class EuphonyApp extends LitElement {
 
   @state()
   codexSessionData: unknown[][] = [];
+
+  @state()
+  atifTrajectoryData: unknown[][] = [];
 
   @state()
   dataType: DataType = DataType.CONVERSATION;
@@ -254,8 +264,12 @@ export class EuphonyApp extends LitElement {
   @state()
   isLoadingFromCache = true;
 
+  // True iff the active dataset was loaded from the user's clipboard. Used to
+  // suppress the share-URL UI for clipboard buffers, which have no addressable
+  // source. File loads clear `blobPath` separately, so they don't need this
+  // flag set to also hide the share URL.
   @state()
-  isLoadingFromClipboard = false;
+  isLoadedFromClipboard = false;
 
   // Grid view mode
   @state()
@@ -1376,6 +1390,7 @@ export class EuphonyApp extends LitElement {
     switch (e.data.command) {
       case 'finishParseData': {
         const { requestID, sourceName, dataType } = e.data.payload;
+        const isClipboardSource = sourceName === 'clipboard';
         const pendingRequest =
           this.localDataWorkerPendingRequests.get(requestID);
         this.localDataWorkerPendingRequests.delete(requestID);
@@ -1387,6 +1402,7 @@ export class EuphonyApp extends LitElement {
         this.isLoadingData = false;
 
         this.codexSessionData = [];
+        this.atifTrajectoryData = [];
         this.allConversationData = [];
         this.conversationData = [];
         this.JSONData = [];
@@ -1398,9 +1414,20 @@ export class EuphonyApp extends LitElement {
           this._totalConversationSize = 1;
           this._totalConversationSizeIncludingUnfiltered = 1;
           this.isLoadingFromCache = false;
-          this.isLoadingFromClipboard = true;
+          this.isLoadedFromClipboard = isClipboardSource;
 
           this.toastMessage = `Codex session loaded successfully from ${sourceName}`;
+          this.toastType = 'success';
+        } else if (dataType === 'atif') {
+          this.atifTrajectoryData = [e.data.payload.atifTrajectoryData];
+          this.selectedConversationIDs = new Set();
+          this.dataType = DataType.ATIF;
+          this._totalConversationSize = 1;
+          this._totalConversationSizeIncludingUnfiltered = 1;
+          this.isLoadingFromCache = false;
+          this.isLoadedFromClipboard = isClipboardSource;
+
+          this.toastMessage = `ATIF loaded successfully from ${sourceName}`;
           this.toastType = 'success';
         } else if (dataType === 'json') {
           this.JSONData = e.data.payload.jsonData;
@@ -1408,7 +1435,7 @@ export class EuphonyApp extends LitElement {
           this._totalConversationSize = this.JSONData.length;
           this._totalConversationSizeIncludingUnfiltered = this.JSONData.length;
           this.isLoadingFromCache = false;
-          this.isLoadingFromClipboard = true;
+          this.isLoadedFromClipboard = isClipboardSource;
 
           this.toastMessage =
             'Failed to find harmony-formatted data. Render JSON instead.';
@@ -1435,7 +1462,7 @@ export class EuphonyApp extends LitElement {
               );
           this.dataType = DataType.CONVERSATION;
           this.isLoadingFromCache = false;
-          this.isLoadingFromClipboard = true;
+          this.isLoadedFromClipboard = isClipboardSource;
 
           this.toastMessage = `Data loaded successfully from ${sourceName}`;
           this.toastType = 'success';
@@ -1511,8 +1538,9 @@ export class EuphonyApp extends LitElement {
     loadedURL: string;
   }> => {
     this.isLoadingData = true;
-    this.isLoadingFromClipboard = false;
+    this.isLoadedFromClipboard = false;
     this.codexSessionData = [];
+    this.atifTrajectoryData = [];
     let loadedURL = blobURL;
     const toastMessages = [];
 
@@ -1545,6 +1573,39 @@ export class EuphonyApp extends LitElement {
       // We know the data is successfully loaded, so we update the URL state
       // early before any follow-up rendering or pagination work.
       blobPath = blobURL;
+
+      if (isAtifTrajectory(data as unknown[])) {
+        this.atifTrajectoryData = [data as unknown[]];
+        this.codexSessionData = [];
+        this.allConversationData = [];
+        this.conversationData = [];
+        this.JSONData = [];
+        this.selectedConversationIDs = new Set();
+        this.dataType = DataType.ATIF;
+        this._totalConversationSize = 1;
+        this._totalConversationSizeIncludingUnfiltered = 1;
+        this.isLoadingData = false;
+        this.isLoadingFromCache = !noCache;
+
+        if (urlHash === '') {
+          this.scrollToTop(0);
+        }
+
+        if (showSuccessToast) {
+          toastMessages.push('ATIF loaded successfully');
+          this.toastMessage = toastMessages.join('\n\n');
+          this.toastType = 'success';
+          if (this.toastComponent) {
+            this.toastComponent.show();
+          }
+        }
+
+        return {
+          isLoadDataSuccessful: true,
+          loadDataMessage: toastMessages.join('\n\n'),
+          loadedURL: loadedURL
+        };
+      }
 
       // Codex sessions are JSONL event streams, not Harmony conversations.
       // Fetch the full event stream if the first page was truncated and route
@@ -1774,7 +1835,8 @@ export class EuphonyApp extends LitElement {
         'euphony-conversation'
       ) ?? []),
       ...(this.shadowRoot?.querySelectorAll<EuphonyCodex>('euphony-codex') ??
-        [])
+        []),
+      ...(this.shadowRoot?.querySelectorAll<EuphonyAtif>('euphony-atif') ?? [])
     ];
   }
 
@@ -1794,6 +1856,9 @@ export class EuphonyApp extends LitElement {
         break;
       case DataType.CODEX:
         conversationList = this.codexSessionData;
+        break;
+      case DataType.ATIF:
+        conversationList = this.atifTrajectoryData;
         break;
       case DataType.JSON:
         conversationList = this.JSONData;
@@ -1820,7 +1885,7 @@ export class EuphonyApp extends LitElement {
               this.isGridView ? undefined : '800'
             )}
             sharing-url=${ifDefined(
-              this.isLoadingFromClipboard ? undefined : url
+              this.isLoadedFromClipboard ? undefined : url
             )}
             data-file-url=${ifDefined(blobPath ?? undefined)}
             focus-mode-author=${JSON.stringify(this.focusModeAuthor)}
@@ -1936,6 +2001,117 @@ export class EuphonyApp extends LitElement {
             }}
           ></euphony-conversation>
         `;
+      } else if (this.dataType === DataType.ATIF) {
+        const curAtifTrajectory = conversation as unknown[];
+        euphonyTemplate = html`
+          <euphony-atif
+            id="euphony-conversation-${curID}"
+            .trajectoryData=${curAtifTrajectory}
+            conversation-max-width=${ifDefined(
+              this.isGridView ? undefined : '800'
+            )}
+            sharing-url=${ifDefined(
+              this.isLoadedFromClipboard ? undefined : url
+            )}
+            focus-mode-author=${JSON.stringify(this.focusModeAuthor)}
+            focus-mode-recipient=${JSON.stringify(this.focusModeRecipient)}
+            focus-mode-content-type=${JSON.stringify(this.focusModeContentType)}
+            ?is-showing-metadata=${this.globalIsShowingMetadata}
+            ?should-render-markdown=${this.globalShouldRenderMarkdown}
+            ?disable-editing-mode-save-button=${true}
+            ?disable-preference-button=${true}
+            ?disable-image-preview-window=${true}
+            ?disable-token-window=${true}
+            theme="light"
+            style=${this.buildEuphonyStyle(this.euphonyStyleConfig)}
+            @refresh-renderer-list-requested=${(
+              e: CustomEvent<RefreshRendererListRequest>
+            ) => {
+              if (this.isFrontendOnlyMode) {
+                this.requestWorker
+                  .frontendOnlyRefreshRendererListRequestHandler(e)
+                  .then(
+                    () => {},
+                    () => {}
+                  );
+              } else {
+                this.requestWorker.refreshRendererListRequestHandler(e).then(
+                  () => {},
+                  () => {}
+                );
+              }
+            }}
+            @harmony-render-requested=${(
+              e: CustomEvent<HarmonyRenderRequest>
+            ) => {
+              if (this.isFrontendOnlyMode) {
+                this.requestWorker
+                  .frontendOnlyHarmonyRenderRequestHandler(e)
+                  .then(
+                    () => {},
+                    () => {}
+                  );
+              } else {
+                this.requestWorker.harmonyRenderRequestHandler(e).then(
+                  () => {},
+                  () => {}
+                );
+              }
+            }}
+            @conversation-metadata-button-toggled=${(
+              e: CustomEvent<boolean>
+            ) => {
+              this.conversationMetadataButtonToggled(e).then(
+                () => {},
+                () => {}
+              );
+            }}
+            @markdown-button-toggled=${(e: CustomEvent<boolean>) => {
+              this.markdownButtonToggled(e).then(
+                () => {},
+                () => {}
+              );
+            }}
+            @translation-requested=${(e: CustomEvent<TranslationRequest>) => {
+              if (this.isFrontendOnlyMode) {
+                this.ensureOpenAIAPIKey()
+                  .then(apiKey => {
+                    if (apiKey) {
+                      this.requestWorker
+                        .frontendOnlyTranslationRequestHandler(e, apiKey)
+                        .then(
+                          () => {},
+                          () => {}
+                        );
+                    } else {
+                      e.detail.reject(
+                        'OpenAI API key is required for frontend-only translation.'
+                      );
+                    }
+                  })
+                  .catch(() => {});
+              } else {
+                this.requestWorker.translationRequestHandler(e).then(
+                  () => {},
+                  () => {}
+                );
+              }
+            }}
+            @fetch-message-sharing-url=${(
+              e: CustomEvent<MessageSharingRequest>
+            ) => {
+              this.requestWorker.fetchMessageSharingURLRequestHandler(
+                e,
+                curID,
+                this.urlManager,
+                blobPath
+              );
+            }}
+            @harmony-render-button-clicked=${(e: CustomEvent<string>) => {
+              this.harmonyRenderButtonClicked(e);
+            }}
+          ></euphony-atif>
+        `;
       } else if (this.dataType === DataType.CODEX) {
         const curCodexSession = conversation as unknown[];
         euphonyTemplate = html`
@@ -1947,7 +2123,7 @@ export class EuphonyApp extends LitElement {
               this.isGridView ? undefined : '800'
             )}
             sharing-url=${ifDefined(
-              this.isLoadingFromClipboard ? undefined : url
+              this.isLoadedFromClipboard ? undefined : url
             )}
             focus-mode-author=${JSON.stringify(this.focusModeAuthor)}
             focus-mode-recipient=${JSON.stringify(this.focusModeRecipient)}

--- a/src/components/app/local-data-parser.test.ts
+++ b/src/components/app/local-data-parser.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { parseLocalData } from './local-data-parser';
+
+function buildSimpleAtif() {
+  return {
+    schema_version: 'ATIF-v1.6',
+    session_id: 'parser-test-session',
+    agent: { name: 'parser-agent', version: '0.1.0' },
+    steps: [
+      {
+        step_id: 1,
+        timestamp: '2026-05-06T12:30:00Z',
+        source: 'system',
+        message: 'You are concise.'
+      },
+      {
+        step_id: 2,
+        timestamp: '2026-05-06T12:30:01Z',
+        source: 'user',
+        message: 'Hello'
+      }
+    ]
+  };
+}
+
+function buildCodexJSONL(): string {
+  // Minimal Codex session JSONL: a session_meta event followed by a
+  // response_item event, matching what `isCodexSessionJSONL` accepts.
+  const sessionMeta = {
+    timestamp: '2026-05-06T12:30:00Z',
+    type: 'session_meta',
+    payload: { id: 'codex-session-1', cwd: '/tmp', originator: 'unit-test' }
+  };
+  const responseItem = {
+    timestamp: '2026-05-06T12:30:01Z',
+    type: 'response_item',
+    payload: { type: 'message', role: 'user', content: [] }
+  };
+  return `${JSON.stringify(sessionMeta)}\n${JSON.stringify(responseItem)}`;
+}
+
+describe('parseLocalData', () => {
+  it('routes a single ATIF JSON document to the atif branch', () => {
+    const result = parseLocalData(JSON.stringify(buildSimpleAtif()));
+    expect(result.dataType).toBe('atif');
+    if (result.dataType === 'atif') {
+      expect(result.atifTrajectoryData.length).toBe(1);
+    }
+  });
+
+  it('detects ATIF before Codex even if the doc contains event-shaped fields', () => {
+    // ATIF docs are allowed to carry extra fields; this fixture mimics the
+    // shape that previously could be misclassified as Codex JSONL.
+    const atif = {
+      ...buildSimpleAtif(),
+      extra: { type: 'response_item', payload: { type: 'message' } }
+    };
+    const result = parseLocalData(JSON.stringify(atif));
+    expect(result.dataType).toBe('atif');
+  });
+
+  it('routes Codex session JSONL to the codex branch', () => {
+    const result = parseLocalData(buildCodexJSONL());
+    expect(result.dataType).toBe('codex');
+    if (result.dataType === 'codex') {
+      expect(result.codexSessionData.length).toBe(2);
+    }
+  });
+
+  it('routes harmony conversation JSONL to the conversation branch', () => {
+    const conversation = {
+      id: 'conv-1',
+      messages: [{ role: 'user', content: [{ text: 'hi' }] }]
+    };
+    const result = parseLocalData(JSON.stringify(conversation));
+    expect(result.dataType).toBe('conversation');
+    if (result.dataType === 'conversation') {
+      expect(result.conversationData[0].id).toBe('conv-1');
+    }
+  });
+
+  it('falls back to the json branch when no harmony shape is found', () => {
+    const result = parseLocalData(JSON.stringify({ unknown: 'shape' }));
+    expect(result.dataType).toBe('json');
+    if (result.dataType === 'json') {
+      expect(result.jsonData[0]).toEqual({ unknown: 'shape' });
+    }
+  });
+
+  it('throws when no JSON or JSONL data could be parsed', () => {
+    expect(() => parseLocalData('')).toThrow(
+      /Failed to read any JSON or JSONL data/
+    );
+  });
+});

--- a/src/components/app/local-data-parser.ts
+++ b/src/components/app/local-data-parser.ts
@@ -1,0 +1,225 @@
+// Pure parsing helpers for the local-data worker. Extracted from
+// `local-data-worker.ts` so the dispatch logic (ATIF / Codex / conversation /
+// JSON) is testable without spinning up a Web Worker (`self.onmessage`).
+
+import type { Conversation } from '../../types/harmony-types';
+import { isAtifTrajectory } from '../../utils/atif-trajectory';
+import { isCodexSessionJSONL } from '../../utils/codex-session';
+
+export type ParsedItem = Record<string, unknown> | string | Conversation;
+
+export type ParseLocalDataResult =
+  | { dataType: 'codex'; codexSessionData: unknown[] }
+  | { dataType: 'atif'; atifTrajectoryData: unknown[] }
+  | { dataType: 'conversation'; conversationData: Conversation[] }
+  | { dataType: 'json'; jsonData: Record<string, unknown>[] };
+
+function isConversation(data: unknown): boolean {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+  return 'messages' in data && Array.isArray(data.messages);
+}
+
+function extractConversationFromJSONL(
+  data: unknown[]
+): Conversation[] | null {
+  let curData: Record<string, Conversation | string>[] | null = null;
+
+  if (
+    data.length > 0 &&
+    typeof data[0] === 'object' &&
+    !isConversation(data[0])
+  ) {
+    curData = data as Record<string, Conversation | string>[];
+  }
+
+  if (data.length > 0 && typeof data[0] === 'string') {
+    let shouldSkipTransformation = false;
+    try {
+      const conversation = JSON.parse(data[0]) as Conversation;
+      if (isConversation(conversation)) {
+        shouldSkipTransformation = true;
+      }
+    } catch (_error) {
+      shouldSkipTransformation = true;
+    }
+
+    if (!shouldSkipTransformation) {
+      curData = [];
+      for (const d of data) {
+        const record = JSON.parse(d as string) as Record<
+          string,
+          Conversation | string
+        >;
+        curData.push(record);
+      }
+    }
+  }
+
+  if (curData !== null) {
+    let conversationKey: string | null = null;
+    let conversationFieldIsString = false;
+
+    for (const key in curData[0]) {
+      if (typeof curData[0][key] === 'string') {
+        try {
+          const conversation = JSON.parse(curData[0][key]) as Conversation;
+          if (isConversation(conversation)) {
+            conversationKey = key;
+            conversationFieldIsString = true;
+            break;
+          }
+        } catch (_error) {
+          continue;
+        }
+      } else if (isConversation(curData[0][key])) {
+        conversationKey = key;
+        break;
+      }
+    }
+
+    if (conversationKey !== null) {
+      const conversationData: Conversation[] = [];
+
+      for (const d of curData) {
+        const conversation = conversationFieldIsString
+          ? (JSON.parse(d[conversationKey] as string) as Conversation)
+          : (d[conversationKey] as Conversation);
+        conversation.metadata ??= {};
+
+        for (const k in d) {
+          if (k !== conversationKey) {
+            conversation.metadata[`euphonyTransformed-${k}`] = d[k];
+          }
+        }
+
+        conversationData.push(conversation);
+      }
+      return conversationData;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Validates that the parsed payload is an array of `Conversation`s and
+ * back-fills `id` from `conversation_id` where missing.
+ *
+ * Note: this function mutates `conversations` in place (rewriting each entry
+ * with a normalized form) — preserved verbatim from the original
+ * `local-data-worker` implementation it was extracted from. Future improvement:
+ * return a new array so the input can be treated as read-only and the type
+ * predicate becomes a true narrowing of unmodified data.
+ */
+function validateAndTransformConversations(
+  conversations: ParsedItem[]
+): conversations is Conversation[] {
+  const allValid: boolean[] = [];
+
+  for (const [i, conversation] of conversations.entries()) {
+    if (typeof conversation === 'string') {
+      const conversationData = JSON.parse(conversation) as Record<
+        string,
+        unknown
+      >;
+      let newItem = conversation;
+
+      if (
+        conversationData.conversation_id !== undefined &&
+        conversationData.id === undefined
+      ) {
+        conversationData.id = conversationData.conversation_id;
+        newItem = JSON.stringify(conversationData);
+      }
+
+      conversations[i] = newItem;
+      allValid.push(Array.isArray(conversationData.messages));
+    } else {
+      const conversationData = conversation as Record<string, unknown>;
+
+      if (
+        conversationData.conversation_id !== undefined &&
+        conversationData.id === undefined
+      ) {
+        conversationData.id = conversationData.conversation_id;
+      }
+
+      conversations[i] = conversationData;
+      allValid.push(Array.isArray(conversationData.messages));
+    }
+  }
+
+  return allValid.every(Boolean);
+}
+
+export function parseSourceText(sourceText: string): ParsedItem[] {
+  const allData: ParsedItem[] = [];
+
+  try {
+    const jsonData = JSON.parse(sourceText) as Record<string, unknown>;
+    allData.push(jsonData);
+    return allData;
+  } catch (_error) {
+    for (const line of sourceText.split('\n')) {
+      try {
+        allData.push(JSON.parse(line) as Record<string, unknown> | string);
+      } catch (_innerError) {
+        // Skip invalid JSONL lines.
+      }
+    }
+  }
+
+  return allData;
+}
+
+// Dispatch order matters: ATIF must be detected before Codex, since an ATIF
+// document with an event-shaped extra field could otherwise be misclassified
+// as Codex JSONL.
+export function parseLocalData(sourceText: string): ParseLocalDataResult {
+  let allData = parseSourceText(sourceText);
+
+  if (allData.length === 0) {
+    throw new Error('Failed to read any JSON or JSONL data.');
+  }
+
+  if (isAtifTrajectory(allData as unknown[])) {
+    return { dataType: 'atif', atifTrajectoryData: allData as unknown[] };
+  }
+
+  if (isCodexSessionJSONL(allData as unknown[])) {
+    return {
+      dataType: 'codex',
+      codexSessionData: allData as unknown[]
+    };
+  }
+
+  const transformedConversationData = extractConversationFromJSONL(
+    allData as unknown[]
+  );
+  if (transformedConversationData) {
+    allData = transformedConversationData;
+  }
+
+  if (!validateAndTransformConversations(allData)) {
+    return {
+      dataType: 'json',
+      jsonData: allData as Record<string, unknown>[]
+    };
+  }
+
+  const conversationData: Conversation[] = [];
+  for (const item of allData) {
+    if (typeof item === 'string') {
+      conversationData.push(JSON.parse(item) as Conversation);
+    } else {
+      conversationData.push(item);
+    }
+  }
+
+  return {
+    dataType: 'conversation',
+    conversationData
+  };
+}

--- a/src/components/app/local-data-worker.ts
+++ b/src/components/app/local-data-worker.ts
@@ -1,7 +1,5 @@
 import type { Conversation } from '../../types/harmony-types';
-import { isCodexSessionJSONL } from '../../utils/codex-session';
-
-type ParsedItem = Record<string, unknown> | string | Conversation;
+import { parseLocalData } from './local-data-parser';
 
 export type LocalDataWorkerMessage =
   | {
@@ -25,6 +23,12 @@ export type LocalDataWorkerMessage =
         | {
             requestID: number;
             sourceName: 'clipboard' | 'file';
+            dataType: 'atif';
+            atifTrajectoryData: unknown[];
+          }
+        | {
+            requestID: number;
+            sourceName: 'clipboard' | 'file';
             dataType: 'conversation';
             conversationData: Conversation[];
           }
@@ -43,204 +47,6 @@ export type LocalDataWorkerMessage =
         message: string;
       };
     };
-
-const isConversation = (data: unknown) => {
-  if (typeof data !== 'object' || data === null) {
-    return false;
-  }
-  return 'messages' in data && Array.isArray(data.messages);
-};
-
-const extractConversationFromJSONL = (
-  data: unknown[]
-): Conversation[] | null => {
-  let curData: Record<string, Conversation | string>[] | null = null;
-
-  if (
-    data.length > 0 &&
-    typeof data[0] === 'object' &&
-    !isConversation(data[0])
-  ) {
-    curData = data as Record<string, Conversation | string>[];
-  }
-
-  if (data.length > 0 && typeof data[0] === 'string') {
-    let shouldSkipTransformation = false;
-    try {
-      const conversation = JSON.parse(data[0]) as Conversation;
-      if (isConversation(conversation)) {
-        shouldSkipTransformation = true;
-      }
-    } catch (_error) {
-      shouldSkipTransformation = true;
-    }
-
-    if (!shouldSkipTransformation) {
-      curData = [];
-      for (const d of data) {
-        const record = JSON.parse(d as string) as Record<
-          string,
-          Conversation | string
-        >;
-        curData.push(record);
-      }
-    }
-  }
-
-  if (curData !== null) {
-    let conversationKey: string | null = null;
-    let conversationFieldIsString = false;
-
-    for (const key in curData[0]) {
-      if (typeof curData[0][key] === 'string') {
-        try {
-          const conversation = JSON.parse(curData[0][key]) as Conversation;
-          if (isConversation(conversation)) {
-            conversationKey = key;
-            conversationFieldIsString = true;
-            break;
-          }
-        } catch (_error) {
-          continue;
-        }
-      } else if (isConversation(curData[0][key])) {
-        conversationKey = key;
-        break;
-      }
-    }
-
-    if (conversationKey !== null) {
-      const conversationData: Conversation[] = [];
-
-      for (const d of curData) {
-        const conversation = conversationFieldIsString
-          ? (JSON.parse(d[conversationKey] as string) as Conversation)
-          : (d[conversationKey] as Conversation);
-        conversation.metadata ??= {};
-
-        for (const k in d) {
-          if (k !== conversationKey) {
-            conversation.metadata[`euphonyTransformed-${k}`] = d[k];
-          }
-        }
-
-        conversationData.push(conversation);
-      }
-      return conversationData;
-    }
-  }
-
-  return null;
-};
-
-const validateAndTransformConversations = (
-  conversations: ParsedItem[]
-): conversations is Conversation[] => {
-  const allValid: boolean[] = [];
-
-  for (const [i, conversation] of conversations.entries()) {
-    if (typeof conversation === 'string') {
-      const conversationData = JSON.parse(conversation) as Record<
-        string,
-        unknown
-      >;
-      let newItem = conversation;
-
-      if (
-        conversationData.conversation_id !== undefined &&
-        conversationData.id === undefined
-      ) {
-        conversationData.id = conversationData.conversation_id;
-        newItem = JSON.stringify(conversationData);
-      }
-
-      conversations[i] = newItem;
-      allValid.push(Array.isArray(conversationData.messages));
-    } else {
-      const conversationData = conversation as Record<string, unknown>;
-
-      if (
-        conversationData.conversation_id !== undefined &&
-        conversationData.id === undefined
-      ) {
-        conversationData.id = conversationData.conversation_id;
-      }
-
-      conversations[i] = conversationData;
-      allValid.push(Array.isArray(conversationData.messages));
-    }
-  }
-
-  return allValid.every(Boolean);
-};
-
-const parseSourceText = (sourceText: string): ParsedItem[] => {
-  const allData: ParsedItem[] = [];
-
-  try {
-    const jsonData = JSON.parse(sourceText) as Record<string, unknown>;
-    allData.push(jsonData);
-    return allData;
-  } catch (_error) {
-    for (const line of sourceText.split('\n')) {
-      try {
-        allData.push(JSON.parse(line) as Record<string, unknown> | string);
-      } catch (_innerError) {
-        // Skip invalid JSONL lines.
-      }
-    }
-  }
-
-  return allData;
-};
-
-const parseLocalData = (
-  sourceText: string
-):
-  | { dataType: 'codex'; codexSessionData: unknown[] }
-  | { dataType: 'conversation'; conversationData: Conversation[] }
-  | { dataType: 'json'; jsonData: Record<string, unknown>[] } => {
-  let allData = parseSourceText(sourceText);
-
-  if (allData.length === 0) {
-    throw new Error('Failed to read any JSON or JSONL data.');
-  }
-
-  if (isCodexSessionJSONL(allData as unknown[])) {
-    return {
-      dataType: 'codex',
-      codexSessionData: allData as unknown[]
-    };
-  }
-
-  const transformedConversationData = extractConversationFromJSONL(
-    allData as unknown[]
-  );
-  if (transformedConversationData) {
-    allData = transformedConversationData;
-  }
-
-  if (!validateAndTransformConversations(allData)) {
-    return {
-      dataType: 'json',
-      jsonData: allData as Record<string, unknown>[]
-    };
-  }
-
-  const conversationData: Conversation[] = [];
-  for (const item of allData) {
-    if (typeof item === 'string') {
-      conversationData.push(JSON.parse(item) as Conversation);
-    } else {
-      conversationData.push(item);
-    }
-  }
-
-  return {
-    dataType: 'conversation',
-    conversationData
-  };
-};
 
 self.onmessage = async (e: MessageEvent<LocalDataWorkerMessage>) => {
   if (e.data.command !== 'startParseData') {

--- a/src/components/atif/atif.css
+++ b/src/components/atif/atif.css
@@ -1,0 +1,21 @@
+@import '../../css/component-global.css';
+
+/* Wrapper for ATIF (Harbor Agent Trajectory Interchange Format) trajectories.
+   Mirrors the codex component's container styling so the two viewers behave
+   identically to the user — we just want a thin shell around the underlying
+   conversation viewer. */
+
+:host {
+  display: block;
+  width: 100%;
+}
+
+.atif-wrapper {
+  width: 100%;
+}
+
+.empty-state {
+  color: var(--gray-600);
+  font-style: italic;
+  padding: 16px;
+}

--- a/src/components/atif/atif.ts
+++ b/src/components/atif/atif.ts
@@ -1,0 +1,243 @@
+/**
+ * <euphony-atif> — viewer for Harbor's ATIF (Agent Trajectory Interchange
+ * Format) trajectories. Mirrors `<euphony-codex>`: parses the input via
+ * `parseAtifTrajectory` and delegates rendering to `<euphony-conversation>`.
+ */
+
+import { css, html, LitElement, PropertyValues, unsafeCSS } from 'lit';
+import { customElement, property, query, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import type { Conversation } from '../../types/harmony-types';
+import { parseAtifTrajectory } from '../../utils/atif-trajectory';
+import type { EuphonyConversation } from '../conversation/conversation';
+import type {
+  FocusModeSettings,
+  MessageLabelSettings
+} from '../preference-window/preference-window';
+
+import '../conversation/conversation';
+import componentCSS from './atif.css?inline';
+
+@customElement('euphony-atif')
+export class EuphonyAtif extends LitElement {
+  /** Raw ATIF trajectory as a JSON string. Used for declarative HTML usage. */
+  @property({ type: String, attribute: 'trajectory-string' })
+  trajectoryString = '';
+
+  /**
+   * Parsed ATIF trajectory data, matching the shape of `<euphony-codex>`'s
+   * `sessionData` for parity. The local-data worker hands us a one-element
+   * array wrapping the trajectory document; `refreshConversationFromTrajectory`
+   * unwraps it before parsing.
+   *
+   * Future improvement: this could be tightened to
+   * `[AtifTrajectory] | null` (or a dedicated runtime type) so call-site
+   * type-checking catches malformed data instead of relying on
+   * `parseAtifTrajectory` to no-op. Kept loose here to mirror the codex
+   * component's public API exactly.
+   */
+  @property({ attribute: false })
+  trajectoryData: unknown[] | null = null;
+
+  @property({ type: String, attribute: 'sharing-url' })
+  sharingURL: string | null = null;
+
+  @property({ type: String, attribute: 'conversation-label' })
+  conversationLabel = 'Trajectory';
+
+  @property({ type: String, attribute: 'conversation-max-width' })
+  conversationMaxWidth: string | null = null;
+
+  @property({ type: String, attribute: 'conversation-style' })
+  conversationStyle = '';
+
+  @property({ type: Boolean, attribute: 'should-render-markdown' })
+  shouldRenderMarkdown = false;
+
+  @property({ type: Boolean, attribute: 'is-showing-metadata' })
+  isShowingMetadata = false;
+
+  @property({ type: Array, attribute: 'focus-mode-author' })
+  focusModeAuthor: string[] = [];
+
+  @property({ type: Array, attribute: 'focus-mode-recipient' })
+  focusModeRecipient: string[] = [];
+
+  @property({ type: Array, attribute: 'focus-mode-content-type' })
+  focusModeContentType: string[] = [];
+
+  @property({ type: Boolean, attribute: 'disable-markdown-button' })
+  disableMarkdownButton = false;
+
+  @property({ type: Boolean, attribute: 'disable-translation-button' })
+  disableTranslationButton = false;
+
+  @property({ type: Boolean, attribute: 'disable-share-button' })
+  disableShareButton = false;
+
+  @property({ type: Boolean, attribute: 'disable-metadata-button' })
+  disableMetadataButton = false;
+
+  @property({ type: Boolean, attribute: 'disable-message-metadata' })
+  disableMessageMetadata = false;
+
+  @property({ type: Boolean, attribute: 'disable-conversation-name' })
+  disableConversationName = false;
+
+  @property({ type: Boolean, attribute: 'disable-preference-button' })
+  disablePreferenceButton = false;
+
+  @property({ type: Boolean, attribute: 'disable-image-preview-window' })
+  disableImagePreviewWindow = false;
+
+  @property({ type: Boolean, attribute: 'disable-token-window' })
+  disableTokenWindow = false;
+
+  @property({ type: Boolean, attribute: 'disable-editing-mode-save-button' })
+  disableEditingModeSaveButton = false;
+
+  @property({ type: Boolean, attribute: 'disable-conversation-id-copy-button' })
+  disableConversationIDCopyButton = false;
+
+  @property({
+    type: String,
+    attribute: 'disable-download-convo-button-tooltip'
+  })
+  disableDownloadConvoButtonTooltip = '';
+
+  @property({ type: String, attribute: 'disable-copy-convo-button-tooltip' })
+  disableCopyConvoButtonTooltip = '';
+
+  @property({ type: String, attribute: 'theme' })
+  theme: 'auto' | 'light' | 'dark' = 'light';
+
+  @state()
+  conversation: Conversation | null = null;
+
+  @state()
+  parseError: string | null = null;
+
+  @query('euphony-conversation')
+  conversationComponent: EuphonyConversation | undefined;
+
+  private refreshConversationFromTrajectory() {
+    // Defensive `Array.isArray` mirrors `<euphony-codex>`'s `sessionData`
+    // handling — runtime callers (declarative HTML, ad-hoc JS) may bypass the
+    // typed property and pass non-array values, so we re-check at runtime.
+    let raw: unknown = null;
+    if (Array.isArray(this.trajectoryData) && this.trajectoryData.length > 0) {
+      raw = this.trajectoryData[0] ?? null;
+    } else if (this.trajectoryString !== '') {
+      try {
+        raw = JSON.parse(this.trajectoryString);
+      } catch (_error) {
+        raw = null;
+      }
+    }
+
+    if (raw === null) {
+      this.conversation = null;
+      this.parseError = 'No ATIF trajectory data found.';
+      return;
+    }
+
+    const parseResult = parseAtifTrajectory(raw);
+    if (!parseResult) {
+      this.conversation = null;
+      this.parseError = 'Unsupported or malformed ATIF trajectory.';
+      return;
+    }
+
+    this.conversation = parseResult.conversation;
+    this.parseError = null;
+  }
+
+  willUpdate(changedProperties: PropertyValues<this>) {
+    if (
+      changedProperties.has('trajectoryString') ||
+      changedProperties.has('trajectoryData')
+    ) {
+      this.refreshConversationFromTrajectory();
+    }
+  }
+
+  render() {
+    if (!this.conversation) {
+      return html`
+        <div class="empty-state">
+          ${this.parseError ?? 'No ATIF trajectory to display.'}
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="atif-wrapper">
+        <euphony-conversation
+          .conversationData=${this.conversation}
+          sharing-url=${ifDefined(this.sharingURL ?? undefined)}
+          conversation-label=${this.conversationLabel}
+          conversation-max-width=${ifDefined(
+            this.conversationMaxWidth ?? undefined
+          )}
+          ?should-render-markdown=${this.shouldRenderMarkdown}
+          ?is-showing-metadata=${this.isShowingMetadata}
+          .focusModeAuthor=${this.focusModeAuthor}
+          .focusModeRecipient=${this.focusModeRecipient}
+          .focusModeContentType=${this.focusModeContentType}
+          ?disable-markdown-button=${this.disableMarkdownButton}
+          ?disable-translation-button=${this.disableTranslationButton}
+          ?disable-share-button=${this.disableShareButton}
+          ?disable-metadata-button=${this.disableMetadataButton}
+          ?disable-message-metadata=${this.disableMessageMetadata}
+          ?disable-conversation-name=${this.disableConversationName}
+          ?disable-preference-button=${this.disablePreferenceButton}
+          ?disable-image-preview-window=${this.disableImagePreviewWindow}
+          ?disable-token-window=${this.disableTokenWindow}
+          ?disable-editing-mode-save-button=${this.disableEditingModeSaveButton}
+          ?disable-conversation-id-copy-button=${this
+            .disableConversationIDCopyButton}
+          disable-download-convo-button-tooltip=${ifDefined(
+            this.disableDownloadConvoButtonTooltip || undefined
+          )}
+          disable-copy-convo-button-tooltip=${ifDefined(
+            this.disableCopyConvoButtonTooltip || undefined
+          )}
+          theme=${this.theme}
+          style=${this.conversationStyle}
+        ></euphony-conversation>
+      </div>
+    `;
+  }
+
+  static styles = [
+    css`
+      ${unsafeCSS(componentCSS)}
+    `
+  ];
+
+  preferenceWindowMessageLabelChanged(e: CustomEvent<MessageLabelSettings>) {
+    this.conversationComponent?.preferenceWindowMessageLabelChanged(e);
+  }
+
+  preferenceWindowFocusModeSettingsChanged(e: CustomEvent<FocusModeSettings>) {
+    this.conversationComponent?.preferenceWindowFocusModeSettingsChanged(e);
+  }
+
+  expandBlockContents() {
+    this.conversationComponent?.expandBlockContents();
+  }
+
+  collapseBlockContents() {
+    this.conversationComponent?.collapseBlockContents();
+  }
+
+  translationButtonClicked() {
+    void this.conversationComponent?.translationButtonClicked();
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'euphony-atif': EuphonyAtif;
+  }
+}

--- a/src/utils/atif-trajectory.test.ts
+++ b/src/utils/atif-trajectory.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it } from 'vitest';
+import { Role } from '../types/harmony-types';
+import {
+  isAtifTrajectory,
+  parseAtifTrajectory,
+  serializeAtifTrajectory,
+  toAtifJSONString,
+  validateAtifTrajectory
+} from './atif-trajectory';
+
+function firstContentText(content: unknown): string {
+  if (!Array.isArray(content) || content.length === 0) return '';
+  const first = content[0] as unknown;
+  if (typeof first === 'string') return first;
+  if (
+    typeof first === 'object' &&
+    first !== null &&
+    'text' in first &&
+    typeof (first as { text?: unknown }).text === 'string'
+  ) {
+    return (first as { text: string }).text;
+  }
+  return '';
+}
+
+function buildSimpleAtif() {
+  return {
+    schema_version: 'ATIF-v1.6',
+    session_id: 'atif-test-session-001',
+    agent: {
+      name: 'test-agent',
+      version: '0.1.0',
+      model_name: 'gpt-4o-mini'
+    },
+    notes: 'ATIF parser test fixture',
+    steps: [
+      {
+        step_id: 1,
+        timestamp: '2026-05-06T12:30:00Z',
+        source: 'system',
+        message: 'You are concise.'
+      },
+      {
+        step_id: 2,
+        timestamp: '2026-05-06T12:30:02Z',
+        source: 'user',
+        message: 'What is 2 + 2?'
+      },
+      {
+        step_id: 3,
+        timestamp: '2026-05-06T12:30:03Z',
+        source: 'agent',
+        message: "I'll calculate it.",
+        reasoning_content: 'Simple arithmetic reasoning.',
+        tool_calls: [
+          {
+            tool_call_id: 'call-1',
+            function_name: 'calculator',
+            arguments: { expression: '2+2' }
+          }
+        ],
+        observation: {
+          results: [{ source_call_id: 'call-1', content: '4' }]
+        }
+      },
+      {
+        step_id: 4,
+        timestamp: '2026-05-06T12:30:04Z',
+        source: 'agent',
+        message: '2 + 2 = 4.'
+      }
+    ]
+  };
+}
+
+describe('ATIF detector', () => {
+  it('accepts both bare and one-element wrapped trajectories', () => {
+    const atif = buildSimpleAtif();
+    expect(isAtifTrajectory(atif)).toBe(true);
+    expect(isAtifTrajectory([atif])).toBe(true);
+  });
+
+  it('rejects non-ATIF shaped payloads', () => {
+    const atif = buildSimpleAtif();
+    expect(
+      isAtifTrajectory({
+        ...atif,
+        schema_version: 'NOT-ATIF'
+      })
+    ).toBe(false);
+    expect(isAtifTrajectory([{ foo: 'bar' }])).toBe(false);
+  });
+});
+
+describe('ATIF parser', () => {
+  it('parses messages, reasoning, tool calls and observations', () => {
+    const parsed = parseAtifTrajectory(buildSimpleAtif());
+    expect(parsed).not.toBeNull();
+
+    const conversation = parsed!.conversation;
+    expect(conversation.id).toBe('atif-test-session-001');
+    expect(conversation.messages.length).toBeGreaterThanOrEqual(7);
+
+    const summary = conversation.messages[0];
+    expect(summary.role).toBe(Role.System);
+    expect(firstContentText(summary.content)).toContain('Harbor ATIF trajectory');
+
+    const userMessage = conversation.messages.find(
+      m =>
+        m.role === Role.User &&
+        firstContentText(m.content).includes('What is 2 + 2?')
+    );
+    expect(userMessage).toBeDefined();
+
+    const reasoningMessage = conversation.messages.find(
+      m =>
+        m.channel === 'analysis' &&
+        firstContentText(m.content).includes('arithmetic')
+    );
+    expect(reasoningMessage).toBeDefined();
+
+    const toolCallMessage = conversation.messages.find(
+      m => m.channel === 'call' && m.name === 'calculator'
+    );
+    expect(toolCallMessage).toBeDefined();
+
+    const toolOutputMessage = conversation.messages.find(
+      m => m.channel === 'output' && m.name === 'calculator'
+    );
+    expect(toolOutputMessage).toBeDefined();
+    expect(firstContentText(toolOutputMessage!.content)).toContain('4');
+  });
+
+  it('returns null for non-ATIF payloads', () => {
+    expect(parseAtifTrajectory([{ foo: 'bar' }])).toBeNull();
+  });
+});
+
+describe('ATIF serializer and validator', () => {
+  it('round-trips through conversation metadata', () => {
+    const atif = buildSimpleAtif();
+    const parsed = parseAtifTrajectory(atif);
+    expect(parsed).not.toBeNull();
+
+    const serialized = serializeAtifTrajectory(parsed!.conversation);
+    expect(serialized).not.toBeNull();
+    expect(serialized).toEqual(atif);
+
+    const jsonString = toAtifJSONString(parsed!.conversation);
+    expect(jsonString).not.toBeNull();
+    expect(JSON.parse(jsonString!)).toEqual(atif);
+  });
+
+  it('reports schema and step-reference validation errors', () => {
+    const baseAtif = buildSimpleAtif();
+    const atifWithErrors = {
+      ...baseAtif,
+      schema_version: 'ATIF-v9.9',
+      steps: [
+        {
+          ...baseAtif.steps[0],
+          step_id: 2
+        },
+        {
+          ...baseAtif.steps[1],
+          step_id: 2
+        },
+        {
+          ...baseAtif.steps[2],
+          step_id: 3,
+          observation: {
+            results: [{ source_call_id: 'missing-call-id', content: '4' }]
+          }
+        }
+      ]
+    };
+
+    const errors = validateAtifTrajectory(atifWithErrors);
+    expect(
+      errors.some(error => error.includes('not in the list of supported versions'))
+    ).toBe(true);
+    expect(errors.some(error => error.includes('steps[0].step_id'))).toBe(true);
+    expect(
+      errors.some(error => error.includes('does not reference any tool_call_id'))
+    ).toBe(true);
+  });
+
+  it('rejects agent-only fields on non-agent steps', () => {
+    const atif = buildSimpleAtif();
+    const invalid = {
+      ...atif,
+      steps: [
+        {
+          ...atif.steps[0],
+          source: 'user',
+          reasoning_content: 'should not be here',
+          tool_calls: [
+            {
+              tool_call_id: 'x',
+              function_name: 'tool',
+              arguments: {}
+            }
+          ]
+        },
+        ...atif.steps.slice(1)
+      ]
+    };
+
+    const errors = validateAtifTrajectory(invalid);
+    expect(
+      errors.some(error =>
+        error.includes('agent-only field') && error.includes('reasoning_content')
+      )
+    ).toBe(true);
+    expect(
+      errors.some(error =>
+        error.includes('agent-only field') && error.includes('tool_calls')
+      )
+    ).toBe(true);
+  });
+
+  it('validates content parts and tool_definitions shape', () => {
+    const atif = buildSimpleAtif();
+    const invalid = {
+      ...atif,
+      agent: {
+        ...atif.agent,
+        tool_definitions: [{ type: 'function' }]
+      },
+      steps: [
+        {
+          ...atif.steps[0],
+          message: [{ type: 'text' }]
+        },
+        ...atif.steps.slice(1)
+      ]
+    };
+
+    const errors = validateAtifTrajectory(invalid);
+    expect(
+      errors.some(error => error.includes('agent.tool_definitions[0].function'))
+    ).toBe(true);
+    expect(
+      errors.some(error =>
+        error.includes("steps[0].message[0] text part requires string 'text'")
+      )
+    ).toBe(true);
+  });
+
+  // Harbor's `ImageSource.media_type` is a Pydantic Literal restricted to four
+  // MIME types — see harbor/src/harbor/models/trajectories/content.py.
+  // The validator should reject any other string.
+  it('rejects image parts with disallowed media_type values', () => {
+    const atif = buildSimpleAtif();
+    const invalid = {
+      ...atif,
+      steps: [
+        {
+          ...atif.steps[0],
+          message: [
+            {
+              type: 'image',
+              source: { media_type: 'image/bmp', path: 'foo.bmp' }
+            }
+          ]
+        },
+        ...atif.steps.slice(1)
+      ]
+    };
+
+    const errors = validateAtifTrajectory(invalid);
+    expect(
+      errors.some(
+        error =>
+          error.includes('steps[0].message[0]') && error.includes('media_type')
+      )
+    ).toBe(true);
+  });
+
+  // Harbor's `ContentPart.validate_content_type` rejects extra fields:
+  //   - text parts may not carry `source`
+  //   - image parts may not carry `text`
+  // See harbor/src/harbor/models/trajectories/content.py.
+  it('rejects content parts that mix text and image fields', () => {
+    const atif = buildSimpleAtif();
+    const invalid = {
+      ...atif,
+      steps: [
+        {
+          ...atif.steps[0],
+          message: [
+            {
+              type: 'text',
+              text: 'hi',
+              source: { media_type: 'image/png', path: 'x.png' }
+            }
+          ]
+        },
+        {
+          ...atif.steps[1],
+          message: [
+            {
+              type: 'image',
+              text: 'caption',
+              source: { media_type: 'image/png', path: 'x.png' }
+            }
+          ]
+        },
+        ...atif.steps.slice(2)
+      ]
+    };
+
+    const errors = validateAtifTrajectory(invalid);
+    expect(
+      errors.some(
+        error =>
+          error.includes('steps[0].message[0]') &&
+          error.includes("'source' is not allowed")
+      )
+    ).toBe(true);
+    expect(
+      errors.some(
+        error =>
+          error.includes('steps[1].message[0]') &&
+          error.includes("'text' is not allowed")
+      )
+    ).toBe(true);
+  });
+
+  it('rejects timestamps that are not strict ISO-8601', () => {
+    const atif = buildSimpleAtif();
+    const invalid = {
+      ...atif,
+      steps: [
+        { ...atif.steps[0], timestamp: '2026-Jan-01' },
+        { ...atif.steps[1], timestamp: '2026/05/06 12:30:02' },
+        { ...atif.steps[2] },
+        { ...atif.steps[3] }
+      ]
+    };
+
+    const errors = validateAtifTrajectory(invalid);
+    expect(
+      errors.some(
+        error =>
+          error.includes('steps[0].timestamp') && error.includes('ISO-8601')
+      )
+    ).toBe(true);
+    expect(
+      errors.some(
+        error =>
+          error.includes('steps[1].timestamp') && error.includes('ISO-8601')
+      )
+    ).toBe(true);
+  });
+
+  it('accepts canonical ISO-8601 timestamps', () => {
+    const atif = buildSimpleAtif();
+    const errors = validateAtifTrajectory(atif);
+    expect(errors.some(error => error.includes('timestamp'))).toBe(false);
+  });
+});

--- a/src/utils/atif-trajectory.ts
+++ b/src/utils/atif-trajectory.ts
@@ -1,0 +1,784 @@
+/**
+ * Reader, writer, and detector for Harbor's Agent Trajectory Interchange
+ * Format (ATIF) — a single-document JSON format (not JSONL) capturing a
+ * complete agent run. Mirrors the public surface of `codex-session.ts`. The
+ * original document is preserved verbatim under
+ * `conversation.metadata.atif_trajectory` for lossless round-trips.
+ *
+ * Schema reference: harbor/rfcs/0001-trajectory-format.md (ATIF v1.0 — v1.6).
+ */
+
+import { config } from '../config/config';
+import type { Conversation, Message } from '../types/harmony-types';
+import { Role } from '../types/harmony-types';
+
+// ATIF schema types — mirror of harbor/src/harbor/models/trajectories/*.py.
+// Extra fields are tolerated where the spec does, so provider-specific
+// metadata round-trips without loss.
+
+/** Versions this module knows how to read and write. */
+export const SUPPORTED_ATIF_SCHEMA_VERSIONS = [
+  'ATIF-v1.0',
+  'ATIF-v1.1',
+  'ATIF-v1.2',
+  'ATIF-v1.3',
+  'ATIF-v1.4',
+  'ATIF-v1.5',
+  'ATIF-v1.6'
+] as const;
+
+export type AtifSchemaVersion = (typeof SUPPORTED_ATIF_SCHEMA_VERSIONS)[number];
+
+export type AtifStepSource = 'system' | 'user' | 'agent';
+
+export type AtifImageMediaType =
+  | 'image/jpeg'
+  | 'image/png'
+  | 'image/gif'
+  | 'image/webp';
+
+export interface AtifImageSource {
+  media_type: AtifImageMediaType;
+  path: string;
+}
+
+export interface AtifContentPart {
+  type: 'text' | 'image';
+  text?: string;
+  source?: AtifImageSource;
+}
+
+export interface AtifToolCall {
+  tool_call_id: string;
+  function_name: string;
+  arguments: Record<string, unknown>;
+}
+
+export interface AtifSubagentTrajectoryRef {
+  session_id: string;
+  trajectory_path?: string | null;
+  extra?: Record<string, unknown> | null;
+}
+
+export interface AtifObservationResult {
+  source_call_id?: string | null;
+  content?: string | AtifContentPart[] | null;
+  subagent_trajectory_ref?: AtifSubagentTrajectoryRef[] | null;
+}
+
+export interface AtifObservation {
+  results: AtifObservationResult[];
+}
+
+export interface AtifMetrics {
+  prompt_tokens?: number | null;
+  completion_tokens?: number | null;
+  cached_tokens?: number | null;
+  cost_usd?: number | null;
+  prompt_token_ids?: number[] | null;
+  completion_token_ids?: number[] | null;
+  logprobs?: number[] | null;
+  extra?: Record<string, unknown> | null;
+}
+
+export interface AtifFinalMetrics {
+  total_prompt_tokens?: number | null;
+  total_completion_tokens?: number | null;
+  total_cached_tokens?: number | null;
+  total_cost_usd?: number | null;
+  total_steps?: number | null;
+  extra?: Record<string, unknown> | null;
+}
+
+export interface AtifAgent {
+  name: string;
+  version: string;
+  model_name?: string | null;
+  tool_definitions?: Record<string, unknown>[] | null;
+  extra?: Record<string, unknown> | null;
+}
+
+export interface AtifStep {
+  step_id: number;
+  timestamp?: string | null;
+  source: AtifStepSource;
+  model_name?: string | null;
+  reasoning_effort?: string | number | null;
+  message: string | AtifContentPart[];
+  reasoning_content?: string | null;
+  tool_calls?: AtifToolCall[] | null;
+  observation?: AtifObservation | null;
+  metrics?: AtifMetrics | null;
+  is_copied_context?: boolean | null;
+  extra?: Record<string, unknown> | null;
+}
+
+export interface AtifTrajectory {
+  // Plain string so unknown future ATIF versions still parse;
+  // `SUPPORTED_ATIF_SCHEMA_VERSIONS` is enforced in `validateAtifTrajectory`.
+  schema_version: string;
+  session_id: string;
+  agent: AtifAgent;
+  steps: AtifStep[];
+  notes?: string | null;
+  final_metrics?: AtifFinalMetrics | null;
+  continued_trajectory_ref?: string | null;
+  extra?: Record<string, unknown> | null;
+}
+
+export interface AtifTrajectoryParseResult {
+  conversation: Conversation;
+  customLabels: string[][];
+}
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isAtifVersion = (value: unknown): value is string =>
+  typeof value === 'string' && value.startsWith('ATIF-');
+
+// Strict ISO-8601 with date + time + timezone (Z or +/-HH:MM). Rejects the
+// engine-permissive shapes Date.parse accepts (e.g. "2025-Jan-01"). Mirrors
+// the constraint harbor enforces server-side via
+// `datetime.fromisoformat(v.replace("Z", "+00:00"))` in
+// harbor/src/harbor/models/trajectories/step.py (`Step.validate_timestamp`).
+const STRICT_ISO_8601_RE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+
+function isStrictIso8601(value: unknown): value is string {
+  if (typeof value !== 'string' || !STRICT_ISO_8601_RE.test(value)) {
+    return false;
+  }
+  return !Number.isNaN(Date.parse(value));
+}
+
+const isPlausibleAtifStep = (value: unknown): boolean =>
+  isRecord(value) &&
+  typeof value.step_id === 'number' &&
+  (value.source === 'system' ||
+    value.source === 'user' ||
+    value.source === 'agent') &&
+  (typeof value.message === 'string' || Array.isArray(value.message));
+
+/**
+ * Returns true if `raw` looks like an ATIF trajectory document. Accepts the
+ * trajectory object itself or a one-element array wrapping it (what
+ * `parseSourceText` produces when JSON.parse succeeds on a single document).
+ */
+export const isAtifTrajectory = (raw: unknown): boolean => {
+  let candidate: unknown = raw;
+  if (Array.isArray(raw)) {
+    if (raw.length !== 1) return false;
+    candidate = raw[0];
+  }
+  if (!isRecord(candidate)) return false;
+  if (!isAtifVersion(candidate.schema_version)) return false;
+  if (typeof candidate.session_id !== 'string') return false;
+
+  const agent = candidate.agent;
+  if (
+    !isRecord(agent) ||
+    typeof agent.name !== 'string' ||
+    typeof agent.version !== 'string'
+  ) {
+    return false;
+  }
+
+  if (!Array.isArray(candidate.steps) || candidate.steps.length === 0) {
+    return false;
+  }
+  // Sample-check up to 5 steps to keep detection cheap on huge trajectories.
+  const sampleSize = Math.min(candidate.steps.length, 5);
+  for (let i = 0; i < sampleSize; i += 1) {
+    if (!isPlausibleAtifStep(candidate.steps[i])) return false;
+  }
+  return true;
+};
+
+// ---------------------------------------------------------------------------
+// Reader: ATIF -> Conversation
+// ---------------------------------------------------------------------------
+
+/** Coerce a possibly-array `raw` into the bare trajectory object. */
+const unwrapTrajectory = (raw: unknown): AtifTrajectory | null => {
+  const candidate: unknown =
+    Array.isArray(raw) && raw.length === 1 ? raw[0] : raw;
+  return isRecord(candidate) ? (candidate as unknown as AtifTrajectory) : null;
+};
+
+const formatJSON = (value: unknown): string => JSON.stringify(value, null, 2);
+function cloneJSON<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+/**
+ * Flatten ATIF content (string or ContentPart[]) to plain text. Image parts
+ * become `[image: <path>]` markers. Anything non-conforming is JSON-stringified
+ * rather than throwing — detection only sample-checks the first 5 steps, so
+ * later steps may have shapes we never validated.
+ */
+const flattenContent = (content: unknown): string => {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return formatJSON(content);
+
+  const parts: string[] = [];
+  for (const part of content) {
+    if (!isRecord(part)) {
+      parts.push(formatJSON(part));
+    } else if (part.type === 'text' && typeof part.text === 'string') {
+      parts.push(part.text);
+    } else if (
+      part.type === 'image' &&
+      isRecord(part.source) &&
+      typeof part.source.path === 'string'
+    ) {
+      parts.push(`[image: ${part.source.path}]`);
+    }
+  }
+  return parts.join('\n');
+};
+
+/**
+ * Parse a strict ISO-8601 timestamp into seconds-since-epoch, or null if the
+ * value is missing or non-conforming.
+ *
+ * Shares its format check with `isStrictIso8601` so the parser cannot accept a
+ * timestamp shape that the validator would reject — i.e. a doc whose validator
+ * errors mention `timestamp must be a strict ISO-8601 string` will also have
+ * `create_time === undefined` here, instead of getting a Date.parse-coerced
+ * value that disagrees with the validator's verdict.
+ */
+const parseTimestampSeconds = (timestamp?: string | null): number | null => {
+  if (!isStrictIso8601(timestamp)) return null;
+  const ms = Date.parse(timestamp);
+  return Number.isNaN(ms) ? null : ms / 1000;
+};
+
+const sourceToRole = (source: AtifStepSource): Role => {
+  switch (source) {
+    case 'system':
+      return Role.System;
+    case 'user':
+      return Role.User;
+    case 'agent':
+      return Role.Assistant;
+  }
+};
+
+/**
+ * Parse an ATIF trajectory into a Euphony Conversation. Returns null if the
+ * input doesn't look like ATIF — callers should fall through to other format
+ * handlers.
+ */
+export const parseAtifTrajectory = (
+  raw: unknown
+): AtifTrajectoryParseResult | null => {
+  if (!isAtifTrajectory(raw)) return null;
+  const trajectory = unwrapTrajectory(raw);
+  if (!trajectory) return null;
+
+  const messages: Message[] = [];
+  const sessionId = trajectory.session_id;
+  const agentName = trajectory.agent.name;
+  const agentVersion = trajectory.agent.version;
+  const defaultModel = trajectory.agent.model_name ?? null;
+
+  // First system message — a one-line session summary, mirroring how the
+  // Codex parser surfaces session_meta at the top of the conversation.
+  const summaryLines = [
+    'Harbor ATIF trajectory',
+    `session_id: ${sessionId}`,
+    `schema: ${trajectory.schema_version}`,
+    `agent: ${agentName} (v${agentVersion})`
+  ];
+  if (defaultModel) summaryLines.push(`model: ${defaultModel}`);
+  if (trajectory.notes) summaryLines.push(`notes: ${trajectory.notes}`);
+  if (trajectory.continued_trajectory_ref) {
+    summaryLines.push(`continued from: ${trajectory.continued_trajectory_ref}`);
+  }
+
+  messages.push({
+    id: `${sessionId}-summary`,
+    role: Role.System,
+    name: 'atif',
+    content: [{ text: summaryLines.join('\n') }],
+    metadata: {
+      atif_section: 'summary',
+      atif_agent: trajectory.agent,
+      atif_schema_version: trajectory.schema_version,
+      atif_notes: trajectory.notes ?? null,
+      atif_extra: trajectory.extra ?? null,
+      atif_continued_trajectory_ref:
+        trajectory.continued_trajectory_ref ?? null
+    }
+  });
+
+  // Walk steps in order. Each yields one primary "dialogue turn" message,
+  // plus optional follow-ups for reasoning, tool calls, and observations.
+  for (const step of trajectory.steps) {
+    const ts = parseTimestampSeconds(step.timestamp);
+    const role = sourceToRole(step.source);
+    // Clone before stashing in metadata: the same `step` (and its `metrics`)
+    // are also referenced by `metadata.atif_trajectory` on the conversation
+    // for round-tripping. If a downstream consumer mutates a message's
+    // metadata (e.g. an inspector adding annotations) the shared reference
+    // would corrupt the source-of-truth document used by
+    // `serializeAtifTrajectory`. Cloning is cheap relative to render cost
+    // and keeps the round-trip invariant even under unfriendly callers.
+    const safeStepForMetadata = cloneJSON(step);
+
+    const baseMetadata: Record<string, unknown> = {
+      atif_step_id: step.step_id,
+      atif_source: step.source,
+      atif_step: safeStepForMetadata
+    };
+    if (step.is_copied_context) baseMetadata.atif_is_copied_context = true;
+    if (step.reasoning_effort != null) {
+      baseMetadata.atif_reasoning_effort = step.reasoning_effort;
+    }
+    if (step.metrics) baseMetadata.atif_metrics = cloneJSON(step.metrics);
+    if (step.model_name) baseMetadata.atif_model_name = step.model_name;
+    if (step.extra) baseMetadata.atif_step_extra = step.extra;
+
+    // 1. Dialogue turn. Empty messages render as `[empty message]` so they
+    //    stay visible in the viewer.
+    const messageText = flattenContent(step.message);
+    messages.push({
+      id: `${sessionId}-step-${step.step_id}`,
+      role,
+      name: step.source === 'agent' ? agentName : undefined,
+      content: [{ text: messageText === '' ? '[empty message]' : messageText }],
+      create_time: ts ?? undefined,
+      metadata: { ...baseMetadata, atif_section: 'step.message' }
+    });
+
+    // 2. Reasoning surfaces on the analysis channel (parity with Codex).
+    if (step.reasoning_content && step.source === 'agent') {
+      messages.push({
+        id: `${sessionId}-step-${step.step_id}-reasoning`,
+        role: Role.Assistant,
+        name: agentName,
+        content: [{ text: step.reasoning_content }],
+        create_time: ts ?? undefined,
+        channel: 'analysis',
+        metadata: { ...baseMetadata, atif_section: 'step.reasoning_content' }
+      });
+    }
+
+    // 3. Tool calls. Track callId → function_name so the matching
+    //    observation can render under the same label.
+    //
+    // Tool-call `arguments` are stringified eagerly here, matching codex-
+    //   session.ts (`code: formatJSON(payload)` ~line 554). The conversation
+    //   viewer renders every message we emit, so there is no off-screen work
+    //   to skip — eager is simpler and equivalent in cost.
+    const callIdToFunctionName = new Map<string, string>();
+    for (const toolCall of step.tool_calls ?? []) {
+      callIdToFunctionName.set(toolCall.tool_call_id, toolCall.function_name);
+      messages.push({
+        id: `${sessionId}-step-${step.step_id}-call-${toolCall.tool_call_id}`,
+        role: Role.Tool,
+        name: toolCall.function_name,
+        recipient: toolCall.function_name,
+        channel: 'call',
+        content: [
+          {
+            content_type: 'code',
+            text: formatJSON(toolCall.arguments),
+            language: 'json'
+          }
+        ],
+        create_time: ts ?? undefined,
+        metadata: {
+          ...baseMetadata,
+          atif_section: 'step.tool_calls',
+          atif_tool_call_id: toolCall.tool_call_id,
+          atif_function_name: toolCall.function_name
+        }
+      });
+    }
+
+    // 4. Observation results. Label preference: matching tool function_name
+    //    → source_call_id → 'environment' (non-tool / system observations).
+    for (const [idx, result] of step.observation?.results.entries() ?? []) {
+      const resultId = `${sessionId}-step-${step.step_id}-obs-${idx}`;
+      const callId = result.source_call_id ?? null;
+      const label =
+        (callId !== null ? callIdToFunctionName.get(callId) : undefined) ??
+        callId ??
+        'environment';
+
+      const subagentRefs = result.subagent_trajectory_ref;
+      if (subagentRefs && subagentRefs.length > 0) {
+        messages.push({
+          id: resultId,
+          role: Role.Tool,
+          name: label,
+          recipient: label,
+          channel: 'output',
+          content: [
+            {
+              content_type: 'code',
+              text: formatJSON(subagentRefs),
+              language: 'json'
+            }
+          ],
+          create_time: ts ?? undefined,
+          metadata: {
+            ...baseMetadata,
+            atif_section: 'step.observation.subagent_trajectory_ref',
+            atif_source_call_id: callId
+          }
+        });
+        continue;
+      }
+
+      messages.push({
+        id: resultId,
+        role: Role.Tool,
+        name: label,
+        recipient: label,
+        channel: 'output',
+        content: [
+          {
+            content_type: 'code',
+            text:
+              result.content == null
+                ? '[empty output]'
+                : flattenContent(result.content),
+            language: 'text'
+          }
+        ],
+        create_time: ts ?? undefined,
+        metadata: {
+          ...baseMetadata,
+          atif_section: 'step.observation.results',
+          atif_source_call_id: callId
+        }
+      });
+    }
+  }
+
+  // First-step timestamp anchors conversation create_time; fall back to "now".
+  // Codex parsers use `events[0].timestamp` directly (codex-session.ts line
+  // ~741) because every Codex event has a timestamp; ATIF's `step.timestamp`
+  // is OPTIONAL per the RFC, so we walk steps until we find a parseable one.
+  let firstTs: number | null = null;
+  for (const step of trajectory.steps) {
+    firstTs = parseTimestampSeconds(step.timestamp);
+    if (firstTs !== null) break;
+  }
+
+  // Side-channel labels shown in the conversation header.
+  const customLabels: string[][] = [
+    ['Session', sessionId.slice(0, 8), sessionId, config.colors['blue-700']],
+    [
+      'Agent',
+      `${agentName}@${agentVersion}`,
+      'ATIF agent name and version',
+      config.colors['purple-700']
+    ]
+  ];
+  if (defaultModel) {
+    customLabels.push([
+      'Model',
+      defaultModel,
+      'Default model from agent.model_name',
+      config.colors['indigo-700']
+    ]);
+  }
+  customLabels.push(
+    [
+      'Schema',
+      trajectory.schema_version,
+      'ATIF schema version',
+      config.colors['gray-700']
+    ],
+    [
+      'Steps',
+      String(trajectory.steps.length),
+      'Number of steps in trajectory',
+      config.colors['green-700']
+    ]
+  );
+
+  return {
+    conversation: {
+      id: sessionId,
+      create_time: firstTs ?? Date.now() / 1000,
+      messages,
+      metadata: {
+        // Original document preserved verbatim for lossless round-trips.
+        atif_trajectory: trajectory,
+        atif_schema_version: trajectory.schema_version,
+        atif_agent: trajectory.agent,
+        atif_final_metrics: trajectory.final_metrics ?? null,
+        atif_step_count: trajectory.steps.length,
+        'euphony-custom-labels': customLabels
+      }
+    },
+    customLabels
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Writer: Conversation -> ATIF
+// ---------------------------------------------------------------------------
+
+/**
+ * Recover the original ATIF trajectory from a Conversation produced by
+ * `parseAtifTrajectory`. Returns null if the conversation was not loaded from
+ * ATIF.
+ *
+ * UX tradeoff (read-only by design):
+ *   This function returns the ORIGINAL parsed document, not a re-serialization
+ *   of the in-memory Conversation. That means user edits made through the
+ *   conversation viewer are not reflected here. The tradeoff is intentional
+ *   and works because `<euphony-atif>` is read-only end-to-end:
+ *
+ *     - The component does not declare an `is-editable` property and the app
+ *       does not pass `?is-editable` to it (see `app.ts`, ATIF render
+ *       branch). The inner `<euphony-conversation>` therefore defaults to
+ *       `isEditable=false`, so the editing UI never appears.
+ *     - `?disable-editing-mode-save-button=${true}` is set as a
+ *       belt-and-suspenders fallback in case someone wires editing in later
+ *       without realizing the writer can't reflect those edits.
+ *
+ *   Synthesizing ATIF from arbitrary Harmony conversations is *not* a
+ *   reasonable alternative: the schema mandates sequential step IDs, an
+ *   `agent.name`/`agent.version` pair, and tool-call → observation
+ *   `source_call_id` references, none of which a generic Harmony
+ *   conversation reliably preserves. If we ever need lossy export of an
+ *   edited trajectory we should build a separate writer that does that
+ *   reconstruction explicitly, rather than silently dropping edits here.
+ */
+export const serializeAtifTrajectory = (
+  conversation: Conversation
+): AtifTrajectory | null => {
+  const stored = isRecord(conversation.metadata)
+    ? conversation.metadata.atif_trajectory
+    : null;
+  if (!isRecord(stored)) return null;
+  // Defensive deep clone so callers can't mutate our internal copy.
+  return JSON.parse(JSON.stringify(stored)) as AtifTrajectory;
+};
+
+/** Serialize a Conversation back to a pretty-printed ATIF JSON string. */
+export const toAtifJSONString = (conversation: Conversation): string | null => {
+  const trajectory = serializeAtifTrajectory(conversation);
+  return trajectory ? JSON.stringify(trajectory, null, 2) : null;
+};
+
+/**
+ * Lightweight runtime validator that mirrors the Pydantic models. Returns an
+ * array of human-readable error strings; an empty array means the document
+ * is valid. Used by the parser-level smoke tests and by callers that want to
+ * surface format errors to the user.
+ */
+export const validateAtifTrajectory = (raw: unknown): string[] => {
+  const errors: string[] = [];
+  const trajectory = unwrapTrajectory(raw);
+  if (!trajectory) {
+    errors.push('Top-level value is not a JSON object');
+    return errors;
+  }
+
+  if (!isAtifVersion(trajectory.schema_version)) {
+    errors.push('schema_version is missing or not an ATIF-* string');
+  } else if (
+    !(SUPPORTED_ATIF_SCHEMA_VERSIONS as readonly string[]).includes(
+      trajectory.schema_version
+    )
+  ) {
+    errors.push(
+      `schema_version "${trajectory.schema_version}" is not in the list of ` +
+        'supported versions ' +
+        `(${SUPPORTED_ATIF_SCHEMA_VERSIONS.join(', ')})`
+    );
+  }
+
+  if (typeof trajectory.session_id !== 'string') {
+    errors.push('session_id is missing or not a string');
+  }
+
+  const agent = trajectory.agent as unknown;
+  if (!isRecord(agent)) {
+    errors.push('agent is missing or not an object');
+  } else {
+    if (typeof agent.name !== 'string') errors.push('agent.name is required');
+    if (typeof agent.version !== 'string')
+      errors.push('agent.version is required');
+    // tool_definitions: harbor's Pydantic model only types this as
+    // `list[dict[str, Any]]` (agent.py), but the RFC § AgentSchema spells
+    // out the per-element shape: "Each element follows OpenAI's function
+    // calling schema with `type` and `function` fields containing the
+    // tool's signature and docs." We enforce that here so a mis-shaped
+    // tool list is caught at validation time rather than at render time.
+    if (agent.tool_definitions != null) {
+      if (!Array.isArray(agent.tool_definitions)) {
+        errors.push('agent.tool_definitions must be an array when provided');
+      } else {
+        for (const [i, toolDef] of agent.tool_definitions.entries()) {
+          if (!isRecord(toolDef)) {
+            errors.push(`agent.tool_definitions[${i}] must be an object`);
+            continue;
+          }
+          if (toolDef.type !== 'function') {
+            errors.push(`agent.tool_definitions[${i}].type must be "function"`);
+          }
+          if (!isRecord(toolDef.function)) {
+            errors.push(`agent.tool_definitions[${i}].function is required`);
+          }
+        }
+      }
+    }
+  }
+
+  if (!Array.isArray(trajectory.steps) || trajectory.steps.length === 0) {
+    errors.push('steps must be a non-empty array');
+    return errors;
+  }
+
+  // ContentPart constraints mirror harbor's Pydantic model:
+  //   harbor/src/harbor/models/trajectories/content.py
+  //   - `type='text'` REQUIRES `text` and forbids `source`
+  //   - `type='image'` REQUIRES `source` and forbids `text`
+  //   - `source.media_type` is a Literal restricted to four MIME types
+  // We enforce all three so a document that fails harbor's server-side
+  // validation also fails ours, instead of looking valid here and then
+  // breaking downstream.
+  const ALLOWED_IMAGE_MEDIA_TYPES = new Set([
+    'image/jpeg',
+    'image/png',
+    'image/gif',
+    'image/webp'
+  ]);
+  const validateContentParts = (path: string, value: unknown) => {
+    if (!Array.isArray(value)) return;
+    for (const [i, part] of value.entries()) {
+      if (!isRecord(part)) {
+        errors.push(`${path}[${i}] must be an object`);
+        continue;
+      }
+      if (part.type === 'text') {
+        if (typeof part.text !== 'string') {
+          errors.push(`${path}[${i}] text part requires string 'text'`);
+        }
+        if (part.source !== undefined) {
+          errors.push(
+            `${path}[${i}] 'source' is not allowed when type is "text"`
+          );
+        }
+        continue;
+      }
+      if (part.type === 'image') {
+        if (part.text !== undefined) {
+          errors.push(
+            `${path}[${i}] 'text' is not allowed when type is "image"`
+          );
+        }
+        if (
+          !isRecord(part.source) ||
+          typeof part.source.path !== 'string' ||
+          typeof part.source.media_type !== 'string'
+        ) {
+          errors.push(
+            `${path}[${i}] image part requires source.path and source.media_type`
+          );
+          continue;
+        }
+        if (!ALLOWED_IMAGE_MEDIA_TYPES.has(part.source.media_type)) {
+          errors.push(
+            `${path}[${i}].source.media_type "${part.source.media_type}" ` +
+              'is not one of image/jpeg, image/png, image/gif, image/webp'
+          );
+        }
+        continue;
+      }
+      errors.push(`${path}[${i}].type must be "text" or "image"`);
+    }
+  };
+
+  const agentOnlyFields = [
+    'model_name',
+    'reasoning_effort',
+    'reasoning_content',
+    'tool_calls',
+    'metrics'
+  ] as const;
+
+  // step_ids must be sequential starting at 1 (per Trajectory.validate_step_ids).
+  for (let i = 0; i < trajectory.steps.length; i += 1) {
+    const step = trajectory.steps[i] as unknown;
+    if (!isRecord(step)) {
+      errors.push(`steps[${i}] is not an object`);
+      continue;
+    }
+    if (step.step_id !== i + 1) {
+      errors.push(
+        `steps[${i}].step_id: expected ${i + 1}, got ${String(step.step_id)}`
+      );
+    }
+    if (
+      step.source !== 'system' &&
+      step.source !== 'user' &&
+      step.source !== 'agent'
+    ) {
+      errors.push(`steps[${i}].source must be system|user|agent`);
+    }
+    if (typeof step.message !== 'string' && !Array.isArray(step.message)) {
+      errors.push(`steps[${i}].message is required`);
+    }
+    if (step.timestamp != null && !isStrictIso8601(step.timestamp)) {
+      errors.push(
+        `steps[${i}].timestamp must be a strict ISO-8601 string when provided`
+      );
+    }
+    validateContentParts(`steps[${i}].message`, step.message);
+
+    if (step.source !== 'agent') {
+      for (const field of agentOnlyFields) {
+        if (step[field] != null) {
+          errors.push(
+            `steps[${i}].${field} is an agent-only field (source is ${String(step.source)})`
+          );
+        }
+      }
+    }
+
+    // observation source_call_id must reference a tool_call_id on the same
+    // step (per validate_tool_call_references).
+    const obs = step.observation;
+    if (!isRecord(obs) || !Array.isArray(obs.results)) continue;
+    const toolCalls = Array.isArray(step.tool_calls) ? step.tool_calls : [];
+    const validIds = new Set(
+      (toolCalls as { tool_call_id?: unknown }[])
+        .map(tc => tc.tool_call_id)
+        .filter((id): id is string => typeof id === 'string')
+    );
+    for (const [j, result] of (
+      obs.results as { source_call_id?: unknown }[]
+    ).entries()) {
+      const resultRecord = result as unknown;
+      if (isRecord(resultRecord) && resultRecord.content != null) {
+        validateContentParts(
+          `steps[${i}].observation.results[${j}].content`,
+          resultRecord.content
+        );
+      }
+      const sid = result.source_call_id;
+      if (typeof sid === 'string' && !validIds.has(sid)) {
+        errors.push(
+          `steps[${i}].observation.results[${j}].source_call_id ` +
+            `'${sid}' does not reference any tool_call_id in the same step`
+        );
+      }
+    }
+  }
+
+  return errors;
+};

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,450 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "async-lru"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/1f/989ecfef8e64109a489fff357450cb73fa73a865a92bd8c272170a6922c2/async_lru-2.3.0.tar.gz", hash = "sha256:89bdb258a0140d7313cf8f4031d816a042202faa61d0ab310a0a538baa1c24b6", size = 16332, upload-time = "2026-03-19T01:04:32.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/e2/c2e3abf398f80732e58b03be77bde9022550d221dd8781bf586bd4d97cc1/async_lru-2.3.0-py3-none-any.whl", hash = "sha256:eea27b01841909316f2cc739807acea1c623df2be8c5cfad7583286397bb8315", size = 8403, upload-time = "2026-03-19T01:04:30.883Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "euphony"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "async-lru" },
+    { name = "fastapi" },
+    { name = "jmespath" },
+    { name = "openai" },
+    { name = "openai-harmony" },
+    { name = "pydantic" },
+    { name = "uvicorn" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "async-lru" },
+    { name = "fastapi" },
+    { name = "jmespath" },
+    { name = "openai" },
+    { name = "openai-harmony" },
+    { name = "pydantic" },
+    { name = "uvicorn" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c1/0cddc6eb17d4c53a99840953f95dd3accdc5cfc7a337b0e9b26476276be9/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e", size = 165725, upload-time = "2026-04-10T14:28:42.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/68/7390a418f10897da93b158f2d5a8bd0bcd73a0f9ec3bb36917085bb759ef/jiter-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:2fb2ce3a7bc331256dfb14cefc34832366bb28a9aca81deaf43bbf2a5659e607", size = 316295, upload-time = "2026-04-10T14:26:24.887Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a0/5854ac00ff63551c52c6c89534ec6aba4b93474e7924d64e860b1c94165b/jiter-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5252a7ca23785cef5d02d4ece6077a1b556a410c591b379f82091c3001e14844", size = 315898, upload-time = "2026-04-10T14:26:26.601Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a1/4f44832650a16b18e8391f1bf1d6ca4909bc738351826bcc198bba4357f4/jiter-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c409578cbd77c338975670ada777add4efd53379667edf0aceea730cabede6fb", size = 343730, upload-time = "2026-04-10T14:26:28.326Z" },
+    { url = "https://files.pythonhosted.org/packages/48/64/a329e9d469f86307203594b1707e11ae51c3348d03bfd514a5f997870012/jiter-0.14.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7ede4331a1899d604463369c730dbb961ffdc5312bc7f16c41c2896415b1304a", size = 370102, upload-time = "2026-04-10T14:26:30.089Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c1/5e3dfc59635aa4d4c7bd20a820ac1d09b8ed851568356802cf1c08edb3cf/jiter-0.14.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:92cd8b6025981a041f5310430310b55b25ca593972c16407af8837d3d7d2ca01", size = 461335, upload-time = "2026-04-10T14:26:31.911Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1b/dd157009dbc058f7b00108f545ccb72a2d56461395c4fc7b9cfdccb00af4/jiter-0.14.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:351bf6eda4e3a7ceb876377840c702e9a3e4ecc4624dbfb2d6463c67ae52637d", size = 378536, upload-time = "2026-04-10T14:26:33.595Z" },
+    { url = "https://files.pythonhosted.org/packages/91/78/256013667b7c10b8834f8e6e54cd3e562d4c6e34227a1596addccc05e38c/jiter-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1dcfbeb93d9ecd9ca128bbf8910120367777973fa193fb9a39c31237d8df165", size = 353859, upload-time = "2026-04-10T14:26:35.098Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d9/137d65ade9093a409fe80955ce60b12bb753722c986467aeda47faf450ad/jiter-0.14.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:ae039aaef8de3f8157ecc1fdd4d85043ac4f57538c245a0afaecb8321ec951c3", size = 357626, upload-time = "2026-04-10T14:26:36.685Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/48/76750835b87029342727c1a268bea8878ab988caf81ee4e7b880900eeb5a/jiter-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7d9d51eb96c82a9652933bd769fe6de66877d6eb2b2440e281f2938c51b5643e", size = 393172, upload-time = "2026-04-10T14:26:38.097Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/60/456c4e81d5c8045279aefe60e9e483be08793828800a4e64add8fdde7f2a/jiter-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d824ca4148b705970bf4e120924a212fdfca9859a73e42bd7889a63a4ea6bb98", size = 520300, upload-time = "2026-04-10T14:26:39.532Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/9f/2020e0984c235f678dced38fe4eec3058cf528e6af36ebf969b410305941/jiter-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ff3a6465b3a0f54b1a430f45c3c0ba7d61ceb45cbc3e33f9e1a7f638d690baf3", size = 553059, upload-time = "2026-04-10T14:26:40.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/32/e2d298e1a22a4bbe6062136d1c7192db7dba003a6975e51d9a9eecabc4c2/jiter-0.14.0-cp312-cp312-win32.whl", hash = "sha256:5dec7c0a3e98d2a3f8a2e67382d0d7c3ac60c69103a4b271da889b4e8bb1e129", size = 206030, upload-time = "2026-04-10T14:26:42.517Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ac/96369141b3d8a4a8e4590e983085efe1c436f35c0cda940dd76d942e3e40/jiter-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:fc7e37b4b8bc7e80a63ad6cfa5fc11fab27dbfea4cc4ae644b1ab3f273dc348f", size = 201603, upload-time = "2026-04-10T14:26:44.328Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c3/75d847f264647017d7e3052bbcc8b1e24b95fa139c320c5f5066fa7a0bdd/jiter-0.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:ee4a72f12847ef29b072aee9ad5474041ab2924106bdca9fcf5d7d965853e057", size = 191525, upload-time = "2026-04-10T14:26:46Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2a/09f70020898507a89279659a1afe3364d57fc1b2c89949081975d135f6f5/jiter-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af72f204cf4d44258e5b4c1745130ac45ddab0e71a06333b01de660ab4187a94", size = 315502, upload-time = "2026-04-10T14:26:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/be/080c96a45cd74f9fce5db4fd68510b88087fb37ffe2541ff73c12db92535/jiter-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b77da71f6e819be5fbcec11a453fde5b1d0267ef6ed487e2a392fd8e14e4e3a", size = 314870, upload-time = "2026-04-10T14:26:49.149Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/5e/2d0fee155826a968a832cc32438de5e2a193292c8721ca70d0b53e58245b/jiter-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f4ea612fe8b84b8b04e51d0e78029ecf3466348e25973f953de6e6a59aa4c1", size = 343406, upload-time = "2026-04-10T14:26:50.762Z" },
+    { url = "https://files.pythonhosted.org/packages/70/af/bf9ee0d3a4f8dc0d679fc1337f874fe60cdbf841ebbb304b374e1c9aaceb/jiter-0.14.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62fe2451f8fcc0240261e6a4df18ecbcd58327857e61e625b2393ea3b468aac9", size = 369415, upload-time = "2026-04-10T14:26:52.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/83/8e8561eadba31f4d3948a5b712fb0447ec71c3560b57a855449e7b8ddc98/jiter-0.14.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6112f26f5afc75bcb475787d29da3aa92f9d09c7858f632f4be6ffe607be82e9", size = 461456, upload-time = "2026-04-10T14:26:53.611Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c9/c5299e826a5fe6108d172b344033f61c69b1bb979dd8d9ddd4278a160971/jiter-0.14.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:215a6cb8fb7dc702aa35d475cc00ddc7f970e5c0b1417fb4b4ac5d82fa2a29db", size = 378488, upload-time = "2026-04-10T14:26:55.211Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/37/c16d9d15c0a471b8644b1abe3c82668092a707d9bedcf076f24ff2e380cd/jiter-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4ab96a30fb3cb2c7e0cd33f7616c8860da5f5674438988a54ac717caccdbaa", size = 353242, upload-time = "2026-04-10T14:26:56.705Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ea/8050cb0dc654e728e1bfacbc0c640772f2181af5dedd13ae70145743a439/jiter-0.14.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:3a99c1387b1f2928f799a9de899193484d66206a50e98233b6b088a7f0c1edb2", size = 356823, upload-time = "2026-04-10T14:26:58.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/cf71506d270e5f84d97326bf220e47aed9b95e9a4a060758fb07772170ab/jiter-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ab18d11074485438695f8d34a1b6da61db9754248f96d51341956607a8f39985", size = 392564, upload-time = "2026-04-10T14:27:00.018Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cc/8c6c74a3efb5bd671bfd14f51e8a73375464ca914b1551bc3b40e26ac2c9/jiter-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:801028dcfc26ac0895e4964cbc0fd62c73be9fd4a7d7b1aaf6e5790033a719b7", size = 520322, upload-time = "2026-04-10T14:27:01.664Z" },
+    { url = "https://files.pythonhosted.org/packages/41/24/68d7b883ec959884ddf00d019b2e0e82ba81b167e1253684fa90519ce33c/jiter-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ad425b087aafb4a1c7e1e98a279200743b9aaf30c3e0ba723aec93f061bd9bc8", size = 552619, upload-time = "2026-04-10T14:27:03.316Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/89/b1a0985223bbf3150ff9e8f46f98fc9360c1de94f48abe271bbe1b465682/jiter-0.14.0-cp313-cp313-win32.whl", hash = "sha256:882bcb9b334318e233950b8be366fe5f92c86b66a7e449e76975dfd6d776a01f", size = 205699, upload-time = "2026-04-10T14:27:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/19/3f339a5a7f14a11730e67f6be34f9d5105751d547b615ef593fa122a5ded/jiter-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:9b8c571a5dba09b98bd3462b5a53f27209a5cbbe85670391692ede71974e979f", size = 201323, upload-time = "2026-04-10T14:27:06.139Z" },
+    { url = "https://files.pythonhosted.org/packages/50/56/752dd89c84be0e022a8ea3720bcfa0a8431db79a962578544812ce061739/jiter-0.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:34f19dcc35cb1abe7c369b3756babf8c7f04595c0807a848df8f26ef8298ef92", size = 191099, upload-time = "2026-04-10T14:27:07.564Z" },
+    { url = "https://files.pythonhosted.org/packages/91/28/292916f354f25a1fe8cf2c918d1415c699a4a659ae00be0430e1c5d9ffea/jiter-0.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e89bcd7d426a75bb4952c696b267075790d854a07aad4c9894551a82c5b574ab", size = 320880, upload-time = "2026-04-10T14:27:09.326Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c7/b002a7d8b8957ac3d469bd59c18ef4b1595a5216ae0de639a287b9816023/jiter-0.14.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b25beaa0d4447ea8c7ae0c18c688905d34840d7d0b937f2f7bdd52162c98a40", size = 346563, upload-time = "2026-04-10T14:27:11.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3b/f8d07580d8706021d255a6356b8fab13ee4c869412995550ce6ed4ddf97d/jiter-0.14.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:651a8758dd413c51e3b7f6557cdc6921faf70b14106f45f969f091f5cda990ea", size = 357928, upload-time = "2026-04-10T14:27:12.729Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5b/ac1a974da29e35507230383110ffec59998b290a8732585d04e19a9eb5ba/jiter-0.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e1a7eead856a5038a8d291f1447176ab0b525c77a279a058121b5fccee257f6f", size = 203519, upload-time = "2026-04-10T14:27:14.125Z" },
+    { url = "https://files.pythonhosted.org/packages/96/6d/9fc8433d667d2454271378a79747d8c76c10b51b482b454e6190e511f244/jiter-0.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e692633a12cda97e352fdcd1c4acc971b1c28707e1e33aeef782b0cbf051975", size = 190113, upload-time = "2026-04-10T14:27:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/1e/354ed92461b165bd581f9ef5150971a572c873ec3b68a916d5aa91da3cc2/jiter-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6f396837fc7577871ca8c12edaf239ed9ccef3bbe39904ae9b8b63ce0a48b140", size = 315277, upload-time = "2026-04-10T14:27:18.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/95/8c7c7028aa8636ac21b7a55faef3e34215e6ed0cbf5ae58258427f621aa3/jiter-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a4d50ea3d8ba4176f79754333bd35f1bbcd28e91adc13eb9b7ca91bc52a6cef9", size = 315923, upload-time = "2026-04-10T14:27:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/47/40/e2a852a44c4a089f2681a16611b7ce113224a80fd8504c46d78491b47220/jiter-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce17f8a050447d1b4153bda4fb7d26e6a9e74eb4f4a41913f30934c5075bf615", size = 344943, upload-time = "2026-04-10T14:27:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/1f/670f92adee1e9895eac41e8a4d623b6da68c4d46249d8b556b60b63f949e/jiter-0.14.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4f1c4b125e1652aefbc2e2c1617b60a160ab789d180e3d423c41439e5f32850", size = 369725, upload-time = "2026-04-10T14:27:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/01/2f/541c9ba567d05de1c4874a0f8f8c5e3fd78e2b874266623da9a775cf46e0/jiter-0.14.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be808176a6a3a14321d18c603f2d40741858a7c4fc982f83232842689fe86dd9", size = 461210, upload-time = "2026-04-10T14:27:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/c31cbec09627e0d5de7aeaec7690dba03e090caa808fefd8133137cf45bc/jiter-0.14.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26679d58ba816f88c3849306dd58cb863a90a1cf352cdd4ef67e30ccf8a77994", size = 380002, upload-time = "2026-04-10T14:27:26.155Z" },
+    { url = "https://files.pythonhosted.org/packages/50/02/3c05c1666c41904a2f607475a73e7a4763d1cbde2d18229c4f85b22dc253/jiter-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80381f5a19af8fa9aef743f080e34f6b25ebd89656475f8cf0470ec6157052aa", size = 354678, upload-time = "2026-04-10T14:27:27.701Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/97/e15b33545c2b13518f560d695f974b9891b311641bdcf178d63177e8801e/jiter-0.14.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:004df5fdb8ecbd6d99f3227df18ba1a259254c4359736a2e6f036c944e02d7c5", size = 358920, upload-time = "2026-04-10T14:27:29.256Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d2/8b1461def6b96ba44530df20d07ef7a1c7da22f3f9bf1727e2d611077bf1/jiter-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cff5708f7ed0fa098f2b53446c6fa74c48469118e5cd7497b4f1cd569ab06928", size = 394512, upload-time = "2026-04-10T14:27:31.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/88/837566dd6ed6e452e8d3205355afd484ce44b2533edfa4ed73a298ea893e/jiter-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:2492e5f06c36a976d25c7cc347a60e26d5470178d44cde1b9b75e60b4e519f28", size = 521120, upload-time = "2026-04-10T14:27:33.299Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6b/b00b45c4d1b4c031777fe161d620b755b5b02cdade1e316dcb46e4471d63/jiter-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:7609cfbe3a03d37bfdbf5052012d5a879e72b83168a363deae7b3a26564d57de", size = 553668, upload-time = "2026-04-10T14:27:34.868Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d8/6fe5b42011d19397433d345716eac16728ac241862a2aac9c91923c7509a/jiter-0.14.0-cp314-cp314-win32.whl", hash = "sha256:7282342d32e357543565286b6450378c3cd402eea333fc1ebe146f1fabb306fc", size = 207001, upload-time = "2026-04-10T14:27:36.455Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/43/5c2e08da1efad5e410f0eaaabeadd954812612c33fbbd8fd5328b489139d/jiter-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd77945f38866a448e73b0b7637366afa814d4617790ecd88a18ca74377e6c02", size = 202187, upload-time = "2026-04-10T14:27:38Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1f/6e39ac0b4cdfa23e606af5b245df5f9adaa76f35e0c5096790da430ca506/jiter-0.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:f2d4c61da0821ee42e0cdf5489da60a6d074306313a377c2b35af464955a3611", size = 192257, upload-time = "2026-04-10T14:27:39.504Z" },
+    { url = "https://files.pythonhosted.org/packages/05/57/7dbc0ffbbb5176a27e3518716608aa464aee2e2887dc938f0b900a120449/jiter-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1bf7ff85517dd2f20a5750081d2b75083c1b269cf75afc7511bdf1f9548beb3b", size = 323441, upload-time = "2026-04-10T14:27:41.039Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6e/7b3314398d8983f06b557aa21b670511ec72d3b79a68ee5e4d9bff972286/jiter-0.14.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8ef8791c3e78d6c6b157c6d360fbb5c715bebb8113bc6a9303c5caff012754a", size = 348109, upload-time = "2026-04-10T14:27:42.552Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4f/8dc674bcd7db6dba566de73c08c763c337058baff1dbeb34567045b27cdc/jiter-0.14.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e74663b8b10da1fe0f4e4703fd7980d24ad17174b6bb35d8498d6e3ebce2ae6a", size = 368328, upload-time = "2026-04-10T14:27:44.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/188e09a1f20906f98bbdec44ed820e19f4e8eb8aff88b9d1a5a497587ff3/jiter-0.14.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1aca29ba52913f78362ec9c2da62f22cdc4c3083313403f90c15460979b84d9b", size = 463301, upload-time = "2026-04-10T14:27:46.717Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f0/19046ef965ed8f349e8554775bb12ff4352f443fbe12b95d31f575891256/jiter-0.14.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b39b7d87a952b79949af5fef44d2544e58c21a28da7f1bae3ef166455c61746", size = 378891, upload-time = "2026-04-10T14:27:48.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c3/da43bd8431ee175695777ee78cf0e93eacbb47393ff493f18c45231b427d/jiter-0.14.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d918a68b26e9fab068c2b5453577ef04943ab2807b9a6275df2a812599a310", size = 360749, upload-time = "2026-04-10T14:27:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/72/26/e054771be889707c6161dbdec9c23d33a9ec70945395d70f07cfea1e9a6f/jiter-0.14.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:b08997c35aee1201c1a5361466a8fb9162d03ae7bf6568df70b6c859f1e654a4", size = 358526, upload-time = "2026-04-10T14:27:51.504Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0f/7bea65ea2a6d91f2bf989ff11a18136644392bf2b0497a1fa50934c30a9c/jiter-0.14.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:260bf7ca20704d58d41f669e5e9fe7fe2fa72901a6b324e79056f5d52e9c9be2", size = 393926, upload-time = "2026-04-10T14:27:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/b1ff7d70deef61ac0b7c6c2f12d2ace950cdeecb4fdc94500a0926802857/jiter-0.14.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:37826e3df29e60f30a382f9294348d0238ef127f4b5d7f5f8da78b5b9e050560", size = 521052, upload-time = "2026-04-10T14:27:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7b/3b0649983cbaf15eda26a414b5b1982e910c67bd6f7b1b490f3cfc76896a/jiter-0.14.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:645be49c46f2900937ba0eaf871ad5183c96858c0af74b6becc7f4e367e36e06", size = 553716, upload-time = "2026-04-10T14:27:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
+    { url = "https://files.pythonhosted.org/packages/21/42/9042c3f3019de4adcb8c16591c325ec7255beea9fcd33a42a43f3b0b1000/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:fbd9e482663ca9d005d051330e4d2d8150bb208a209409c10f7e7dfdf7c49da9", size = 308810, upload-time = "2026-04-10T14:28:34.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cf/a7e19b308bd86bb04776803b1f01a5f9a287a4c55205f4708827ee487fbf/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:33a20d838b91ef376b3a56896d5b04e725c7df5bc4864cc6569cf046a8d73b6d", size = 308443, upload-time = "2026-04-10T14:28:36.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/44/e26ede3f0caeff93f222559cb0cc4ca68579f07d009d7b6010c5b586f9b1/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016", size = 343039, upload-time = "2026-04-10T14:28:38.356Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e9/1f9ada30cef7b05e74bb06f52127e7a724976c225f46adb65c37b1dadfb6/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a", size = 349613, upload-time = "2026-04-10T14:28:40.066Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.34.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/89/f1e78f5f828f4e97a6ebca8f45c6b35667da12b074ac490dc8362b882279/openai-2.34.0.tar.gz", hash = "sha256:828b4efcbb126352c2b5eb97d33ae890c92a71ab72511aefc1b7fe64aeccb07b", size = 759556, upload-time = "2026-05-04T17:34:08.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/40/f090499f10514515081d09cb9da09f25b821eb20497e9423afe4f07b4ecf/openai-2.34.0-py3-none-any.whl", hash = "sha256:c996a71b1a210f3569844572ad4c609307e978515fb76877cf449b72596e549e", size = 1316535, upload-time = "2026-05-04T17:34:06.773Z" },
+]
+
+[[package]]
+name = "openai-harmony"
+version = "0.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/92/2d038d096f29179c7c9571b431f9e739f87a487121901725e23fe338dd9d/openai_harmony-0.0.8.tar.gz", hash = "sha256:6e43f98e6c242fa2de6f8ea12eab24af63fa2ed3e89c06341fb9d92632c5cbdf", size = 284777, upload-time = "2025-11-05T19:07:06.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/c6/2502f416d46be3ec08bb66d696cccffb57781a499e3ff2e4d7c174af4e8f/openai_harmony-0.0.8-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:029ec25ca74abe48fdb58eb9fdd2a8c1618581fc33ce8e5653f8a1ffbfbd9326", size = 2627806, upload-time = "2025-11-05T19:06:57.063Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/d2/ce6953ca87db9cae3e775024184da7d1c5cb88cead19a2d75b42f00a959c/openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4f709815924ec325b9a890e6ab2bbb0ceec8e319a4e257328eb752cf36b2efc", size = 2948463, upload-time = "2025-11-05T19:06:48.17Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/4c/b553c9651662d6ce102ca7f3629d268b23df1abe5841e24bed81e8a8e949/openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5cfcfd963b50a41fc656c84d3440ca6eecdccd6c552158ce790b8f2e33dfb5a9", size = 2704083, upload-time = "2025-11-05T19:06:50.205Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/af/4eec8f9ab9c27bcdb444460c72cf43011d176fc44c79d6e113094ca1e152/openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a3a16972aa1cee38ea958470cd04ac9a2d5ac38fdcf77ab686611246220c158", size = 2959765, upload-time = "2025-11-05T19:06:53.62Z" },
+    { url = "https://files.pythonhosted.org/packages/11/3c/33f3374e4624e0e776f6b13b73c45a7ead7f9c4529f8369ed5bfcaa30cac/openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b4d5cfa168e74d08f8ba6d58a7e49bc7daef4d58951ec69b66b0d56f4927a68d", size = 3427031, upload-time = "2025-11-05T19:06:51.829Z" },
+    { url = "https://files.pythonhosted.org/packages/25/3f/1a192b93bb47c6b44cd98ba8cc1d3d2a9308f1bb700c3017e6352da11bda/openai_harmony-0.0.8-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c007d277218a50db8839e599ed78e0fffe5130f614c3f6d93ae257f282071a29", size = 2953260, upload-time = "2025-11-05T19:06:55.406Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f8/93b582cad3531797c3db7c2db5400fd841538ccddfd9f5e3df61be99a630/openai_harmony-0.0.8-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:8565d4f5a0638da1bffde29832ed63c9e695c558611053add3b2dc0b56c92dbc", size = 3127044, upload-time = "2025-11-05T19:06:59.553Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/10/4327dbf87f75ae813405fd9a9b4a5cde63d506ffed0a096a440a4cabd89c/openai_harmony-0.0.8-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:cbaa3bda75ef0d8836e1f8cc84af62f971b1d756d740efc95c38c3e04c0bfde2", size = 2932931, upload-time = "2025-11-05T19:07:01.437Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/c8/1774eec4f6f360ef57618fb8f52e3d3af245b2491bd0297513aa09eec04b/openai_harmony-0.0.8-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:772922a9bd24e133950fad71eb1550836f415a88e8c77870e12d0c3bd688ddc2", size = 2996140, upload-time = "2025-11-05T19:07:03.438Z" },
+    { url = "https://files.pythonhosted.org/packages/60/c3/3d1e01e2dba517a91760e4a03e4f20ffc75039a6fe584d0e6f9b5c78fd15/openai_harmony-0.0.8-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:007b0476a1f331f8130783f901f1da6f5a7057af1a4891f1b6a31dec364189b5", size = 3205080, upload-time = "2025-11-05T19:07:05.078Z" },
+    { url = "https://files.pythonhosted.org/packages/14/63/119de431572d7c70a7bf1037034a9be6ed0a7502a7498ba7302bca5b3242/openai_harmony-0.0.8-cp38-abi3-win32.whl", hash = "sha256:a9b5f893326b28d9e935ade14b4f655f5a840942473bc89b201c25f7a15af9cf", size = 2082457, upload-time = "2025-11-05T19:07:09.631Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/c83cf5a206c263ee70448a5ae4264682555f4d0b5bed0d2cc6ca1108103d/openai_harmony-0.0.8-cp38-abi3-win_amd64.whl", hash = "sha256:39d44f0d8f466bd56698e7ead708bead3141e27b9b87e3ab7d5a6d0e4a869ee5", size = 2438369, upload-time = "2025-11-05T19:07:08.1Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981, upload-time = "2026-04-20T14:46:41.402Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/cb/5b47425556ecc1f3fe18ed2a0083188aa46e1dd812b06e406475b3a5d536/pydantic_core-2.46.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b11b59b3eee90a80a36701ddb4576d9ae31f93f05cb9e277ceaa09e6bf074a67", size = 2101946, upload-time = "2026-04-20T14:40:52.581Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4f/2fb62c2267cae99b815bbf4a7b9283812c88ca3153ef29f7707200f1d4e5/pydantic_core-2.46.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:af8653713055ea18a3abc1537fe2ebc42f5b0bbb768d1eb79fd74eb47c0ac089", size = 1951612, upload-time = "2026-04-20T14:42:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6e/b7348fd30d6556d132cddd5bd79f37f96f2601fe0608afac4f5fb01ec0b3/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75a519dab6d63c514f3a81053e5266c549679e4aa88f6ec57f2b7b854aceb1b0", size = 1977027, upload-time = "2026-04-20T14:42:02.001Z" },
+    { url = "https://files.pythonhosted.org/packages/82/11/31d60ee2b45540d3fb0b29302a393dbc01cd771c473f5b5147bcd353e593/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6cd87cb1575b1ad05ba98894c5b5c96411ef678fa2f6ed2576607095b8d9789", size = 2063008, upload-time = "2026-04-20T14:44:17.952Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/db/3a9d1957181b59258f44a2300ab0f0be9d1e12d662a4f57bb31250455c52/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f80a55484b8d843c8ada81ebf70a682f3f00a3d40e378c06cf17ecb44d280d7d", size = 2233082, upload-time = "2026-04-20T14:40:57.934Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e1/3277c38792aeb5cfb18c2f0c5785a221d9ff4e149abbe1184d53d5f72273/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3861f1731b90c50a3266316b9044f5c9b405eecb8e299b0a7120596334e4fe9c", size = 2304615, upload-time = "2026-04-20T14:42:12.584Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d5/e3d9717c9eba10855325650afd2a9cba8e607321697f18953af9d562da2f/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb528e295ed31570ac3dcc9bfdd6e0150bc11ce6168ac87a8082055cf1a67395", size = 2094380, upload-time = "2026-04-20T14:43:05.522Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/20/abac35dedcbfd66c6f0b03e4e3564511771d6c9b7ede10a362d03e110d9b/pydantic_core-2.46.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:367508faa4973b992b271ba1494acaab36eb7e8739d1e47be5035fb1ea225396", size = 2135429, upload-time = "2026-04-20T14:41:55.549Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a5/41bfd1df69afad71b5cf0535055bccc73022715ad362edbc124bc1e021d7/pydantic_core-2.46.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ad3c826fe523e4becf4fe39baa44286cff85ef137c729a2c5e269afbfd0905d", size = 2174582, upload-time = "2026-04-20T14:41:45.96Z" },
+    { url = "https://files.pythonhosted.org/packages/79/65/38d86ea056b29b2b10734eb23329b7a7672ca604df4f2b6e9c02d4ee22fe/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ec638c5d194ef8af27db69f16c954a09797c0dc25015ad6123eb2c73a4d271ca", size = 2187533, upload-time = "2026-04-20T14:40:55.367Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a1129141678a2026badc539ad1dee0a71d06f54c2f06a4bd68c030ac781b/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:28ed528c45446062ee66edb1d33df5d88828ae167de76e773a3c7f64bd14e976", size = 2332985, upload-time = "2026-04-20T14:44:13.05Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/60/cb26f4077719f709e54819f4e8e1d43f4091f94e285eb6bd21e1190a7b7c/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aed19d0c783886d5bd86d80ae5030006b45e28464218747dcf83dabfdd092c7b", size = 2373670, upload-time = "2026-04-20T14:41:53.421Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/7e/c3f21882bdf1d8d086876f81b5e296206c69c6082551d776895de7801fa0/pydantic_core-2.46.3-cp312-cp312-win32.whl", hash = "sha256:06d5d8820cbbdb4147578c1fe7ffcd5b83f34508cb9f9ab76e807be7db6ff0a4", size = 1966722, upload-time = "2026-04-20T14:44:30.588Z" },
+    { url = "https://files.pythonhosted.org/packages/57/be/6b5e757b859013ebfbd7adba02f23b428f37c86dcbf78b5bb0b4ffd36e99/pydantic_core-2.46.3-cp312-cp312-win_amd64.whl", hash = "sha256:c3212fda0ee959c1dd04c60b601ec31097aaa893573a3a1abd0a47bcac2968c1", size = 2072970, upload-time = "2026-04-20T14:42:54.248Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f8/a989b21cc75e9a32d24192ef700eea606521221a89faa40c919ce884f2b1/pydantic_core-2.46.3-cp312-cp312-win_arm64.whl", hash = "sha256:f1f8338dd7a7f31761f1f1a3c47503a9a3b34eea3c8b01fa6ee96408affb5e72", size = 2035963, upload-time = "2026-04-20T14:44:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3c/9b5e8eb9821936d065439c3b0fb1490ffa64163bfe7e1595985a47896073/pydantic_core-2.46.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:12bc98de041458b80c86c56b24df1d23832f3e166cbaff011f25d187f5c62c37", size = 2102109, upload-time = "2026-04-20T14:41:24.219Z" },
+    { url = "https://files.pythonhosted.org/packages/91/97/1c41d1f5a19f241d8069f1e249853bcce378cdb76eec8ab636d7bc426280/pydantic_core-2.46.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:85348b8f89d2c3508b65b16c3c33a4da22b8215138d8b996912bb1532868885f", size = 1951820, upload-time = "2026-04-20T14:42:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b4/d03a7ae14571bc2b6b3c7b122441154720619afe9a336fa3a95434df5e2f/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1105677a6df914b1fb71a81b96c8cce7726857e1717d86001f29be06a25ee6f8", size = 1977785, upload-time = "2026-04-20T14:42:31.648Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0c/4086f808834b59e3c8f1aa26df8f4b6d998cdcf354a143d18ef41529d1fe/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87082cd65669a33adeba5470769e9704c7cf026cc30afb9cc77fd865578ebaad", size = 2062761, upload-time = "2026-04-20T14:40:37.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/a649be5a5064c2df0db06e0a512c2281134ed2fcc981f52a657936a7527c/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e5f66e12c4f5212d08522963380eaaeac5ebd795826cfd19b2dfb0c7a52b9c", size = 2232989, upload-time = "2026-04-20T14:42:59.254Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/7756e75763e810b3a710f4724441d1ecc5883b94aacb07ca71c5fb5cfb69/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b6cdf19bf84128d5e7c37e8a73a0c5c10d51103a650ac585d42dd6ae233f2b7f", size = 2303975, upload-time = "2026-04-20T14:41:32.287Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/35/68a762e0c1e31f35fa0dac733cbd9f5b118042853698de9509c8e5bf128b/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031bb17f4885a43773c8c763089499f242aee2ea85cf17154168775dccdecf35", size = 2095325, upload-time = "2026-04-20T14:42:47.685Z" },
+    { url = "https://files.pythonhosted.org/packages/77/bf/1bf8c9a8e91836c926eae5e3e51dce009bf495a60ca56060689d3df3f340/pydantic_core-2.46.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:bcf2a8b2982a6673693eae7348ef3d8cf3979c1d63b54fca7c397a635cc68687", size = 2133368, upload-time = "2026-04-20T14:41:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/50/87d818d6bab915984995157ceb2380f5aac4e563dddbed6b56f0ed057aba/pydantic_core-2.46.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28e8cf2f52d72ced402a137145923a762cbb5081e48b34312f7a0c8f55928ec3", size = 2173908, upload-time = "2026-04-20T14:42:52.044Z" },
+    { url = "https://files.pythonhosted.org/packages/91/88/a311fb306d0bd6185db41fa14ae888fb81d0baf648a761ae760d30819d33/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:17eaface65d9fc5abb940003020309c1bf7a211f5f608d7870297c367e6f9022", size = 2186422, upload-time = "2026-04-20T14:43:29.55Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/79/28fd0d81508525ab2054fef7c77a638c8b5b0afcbbaeee493cf7c3fef7e1/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:93fd339f23408a07e98950a89644f92c54d8729719a40b30c0a30bb9ebc55d23", size = 2332709, upload-time = "2026-04-20T14:42:16.134Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/21/795bf5fe5c0f379308b8ef19c50dedab2e7711dbc8d0c2acf08f1c7daa05/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:23cbdb3aaa74dfe0837975dbf69b469753bbde8eacace524519ffdb6b6e89eb7", size = 2372428, upload-time = "2026-04-20T14:41:10.974Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b3/ed14c659cbe7605e3ef063077680a64680aec81eb1a04763a05190d49b7f/pydantic_core-2.46.3-cp313-cp313-win32.whl", hash = "sha256:610eda2e3838f401105e6326ca304f5da1e15393ae25dacae5c5c63f2c275b13", size = 1965601, upload-time = "2026-04-20T14:41:42.128Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/adb70d9a762ddd002d723fbf1bd492244d37da41e3af7b74ad212609027e/pydantic_core-2.46.3-cp313-cp313-win_amd64.whl", hash = "sha256:68cc7866ed863db34351294187f9b729964c371ba33e31c26f478471c52e1ed0", size = 2071517, upload-time = "2026-04-20T14:43:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/52/eb/66faefabebfe68bd7788339c9c9127231e680b11906368c67ce112fdb47f/pydantic_core-2.46.3-cp313-cp313-win_arm64.whl", hash = "sha256:f64b5537ac62b231572879cd08ec05600308636a5d63bcbdb15063a466977bec", size = 2035802, upload-time = "2026-04-20T14:43:38.507Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/db/a7bcb4940183fda36022cd18ba8dd12f2dff40740ec7b58ce7457befa416/pydantic_core-2.46.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:afa3aa644f74e290cdede48a7b0bee37d1c35e71b05105f6b340d484af536d9b", size = 2097614, upload-time = "2026-04-20T14:44:38.374Z" },
+    { url = "https://files.pythonhosted.org/packages/24/35/e4066358a22e3e99519db370494c7528f5a2aa1367370e80e27e20283543/pydantic_core-2.46.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ced3310e51aa425f7f77da8bbbb5212616655bedbe82c70944320bc1dbe5e018", size = 1951896, upload-time = "2026-04-20T14:40:53.996Z" },
+    { url = "https://files.pythonhosted.org/packages/87/92/37cf4049d1636996e4b888c05a501f40a43ff218983a551d57f9d5e14f0d/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e29908922ce9da1a30b4da490bd1d3d82c01dcfdf864d2a74aacee674d0bfa34", size = 1979314, upload-time = "2026-04-20T14:41:49.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/9ff4d676dfbdfb2d591cf43f3d90ded01e15b1404fd101180ed2d62a2fd3/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0c9ff69140423eea8ed2d5477df3ba037f671f5e897d206d921bc9fdc39613e7", size = 2056133, upload-time = "2026-04-20T14:42:23.574Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f0/405b442a4d7ba855b06eec8b2bf9c617d43b8432d099dfdc7bf999293495/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b675ab0a0d5b1c8fdb81195dc5bcefea3f3c240871cdd7ff9a2de8aa50772eb2", size = 2228726, upload-time = "2026-04-20T14:44:22.816Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f8/65cd92dd5a0bd89ba277a98ecbfaf6fc36bbd3300973c7a4b826d6ab1391/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0087084960f209a9a4af50ecd1fb063d9ad3658c07bb81a7a53f452dacbfb2ba", size = 2301214, upload-time = "2026-04-20T14:44:48.792Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/86/ef96a4c6e79e7a2d0410826a68fbc0eccc0fd44aa733be199d5fcac3bb87/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed42e6cc8e1b0e2b9b96e2276bad70ae625d10d6d524aed0c93de974ae029f9f", size = 2099927, upload-time = "2026-04-20T14:41:40.196Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/53/269caf30e0096e0a8a8f929d1982a27b3879872cca2d917d17c2f9fdf4fe/pydantic_core-2.46.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:f1771ce258afb3e4201e67d154edbbae712a76a6081079fe247c2f53c6322c22", size = 2128789, upload-time = "2026-04-20T14:41:15.868Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b0/1a6d9b6a587e118482910c244a1c5acf4d192604174132efd12bf0ac486f/pydantic_core-2.46.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a7610b6a5242a6c736d8ad47fd5fff87fcfe8f833b281b1c409c3d6835d9227f", size = 2173815, upload-time = "2026-04-20T14:44:25.152Z" },
+    { url = "https://files.pythonhosted.org/packages/87/56/e7e00d4041a7e62b5a40815590114db3b535bf3ca0bf4dca9f16cef25246/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:ff5e7783bcc5476e1db448bf268f11cb257b1c276d3e89f00b5727be86dd0127", size = 2181608, upload-time = "2026-04-20T14:41:28.933Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/22/4bd23c3d41f7c185d60808a1de83c76cf5aeabf792f6c636a55c3b1ec7f9/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:9d2e32edcc143bc01e95300671915d9ca052d4f745aa0a49c48d4803f8a85f2c", size = 2326968, upload-time = "2026-04-20T14:42:03.962Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ac/66cd45129e3915e5ade3b292cb3bc7fd537f58f8f8dbdaba6170f7cabb74/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d83d1c6b87fa56b521479cff237e626a292f3b31b6345c15a99121b454c1", size = 2369842, upload-time = "2026-04-20T14:41:35.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/dd4248abb84113615473aa20d5545b7c4cd73c8644003b5259686f93996c/pydantic_core-2.46.3-cp314-cp314-win32.whl", hash = "sha256:07bc6d2a28c3adb4f7c6ae46aa4f2d2929af127f587ed44057af50bf1ce0f505", size = 1959661, upload-time = "2026-04-20T14:41:00.042Z" },
+    { url = "https://files.pythonhosted.org/packages/20/eb/59980e5f1ae54a3b86372bd9f0fa373ea2d402e8cdcd3459334430f91e91/pydantic_core-2.46.3-cp314-cp314-win_amd64.whl", hash = "sha256:8940562319bc621da30714617e6a7eaa6b98c84e8c685bcdc02d7ed5e7c7c44e", size = 2071686, upload-time = "2026-04-20T14:43:16.471Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/db/1cf77e5247047dfee34bc01fa9bca134854f528c8eb053e144298893d370/pydantic_core-2.46.3-cp314-cp314-win_arm64.whl", hash = "sha256:5dcbbcf4d22210ced8f837c96db941bdb078f419543472aca5d9a0bb7cddc7df", size = 2026907, upload-time = "2026-04-20T14:43:31.732Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c0/b3df9f6a543276eadba0a48487b082ca1f201745329d97dbfa287034a230/pydantic_core-2.46.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d0fe3dce1e836e418f912c1ad91c73357d03e556a4d286f441bf34fed2dbeecf", size = 2095047, upload-time = "2026-04-20T14:42:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/66/57/886a938073b97556c168fd99e1a7305bb363cd30a6d2c76086bf0587b32a/pydantic_core-2.46.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9ce92e58abc722dac1bf835a6798a60b294e48eb0e625ec9fd994b932ac5feee", size = 1934329, upload-time = "2026-04-20T14:43:49.655Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7c/b42eaa5c34b13b07ecb51da21761297a9b8eb43044c864a035999998f328/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a03e6467f0f5ab796a486146d1b887b2dc5e5f9b3288898c1b1c3ad974e53e4a", size = 1974847, upload-time = "2026-04-20T14:42:10.737Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9b/92b42db6543e7de4f99ae977101a2967b63122d4b6cf7773812da2d7d5b5/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2798b6ba041b9d70acfb9071a2ea13c8456dd1e6a5555798e41ba7b0790e329c", size = 2041742, upload-time = "2026-04-20T14:40:44.262Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/19/46fbe1efabb5aa2834b43b9454e70f9a83ad9c338c1291e48bdc4fecf167/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9be3e221bdc6d69abf294dcf7aff6af19c31a5cdcc8f0aa3b14be29df4bd03b1", size = 2236235, upload-time = "2026-04-20T14:41:27.307Z" },
+    { url = "https://files.pythonhosted.org/packages/77/da/b3f95bc009ad60ec53120f5d16c6faa8cabdbe8a20d83849a1f2b8728148/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13936129ce841f2a5ddf6f126fea3c43cd128807b5a59588c37cf10178c2e64", size = 2282633, upload-time = "2026-04-20T14:44:33.271Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/401336117722e28f32fb8220df676769d28ebdf08f2f4469646d404c43a3/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28b5f2ef03416facccb1c6ef744c69793175fd27e44ef15669201601cf423acb", size = 2109679, upload-time = "2026-04-20T14:44:41.065Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/53/b289f9bc8756a32fe718c46f55afaeaf8d489ee18d1a1e7be1db73f42cc4/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:830d1247d77ad23852314f069e9d7ddafeec5f684baf9d7e7065ed46a049c4e6", size = 2108342, upload-time = "2026-04-20T14:42:50.144Z" },
+    { url = "https://files.pythonhosted.org/packages/10/5b/8292fc7c1f9111f1b2b7c1b0dcf1179edcd014fc3ea4517499f50b829d71/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0793c90c1a3c74966e7975eaef3ed30ebdff3260a0f815a62a22adc17e4c01c", size = 2157208, upload-time = "2026-04-20T14:42:08.133Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9e/f80044e9ec07580f057a89fc131f78dda7a58751ddf52bbe05eaf31db50f/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d2d0aead851b66f5245ec0c4fb2612ef457f8bbafefdf65a2bf9d6bac6140f47", size = 2167237, upload-time = "2026-04-20T14:42:25.412Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/84/6781a1b037f3b96be9227edbd1101f6d3946746056231bf4ac48cdff1a8d/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:2f40e4246676beb31c5ce77c38a55ca4e465c6b38d11ea1bd935420568e0b1ab", size = 2312540, upload-time = "2026-04-20T14:40:40.313Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/db/19c0839feeb728e7df03255581f198dfdf1c2aeb1e174a8420b63c5252e5/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:cf489cf8986c543939aeee17a09c04d6ffb43bfef8ca16fcbcc5cfdcbed24dba", size = 2369556, upload-time = "2026-04-20T14:41:09.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/15/3228774cb7cd45f5f721ddf1b2242747f4eb834d0c491f0c02d606f09fed/pydantic_core-2.46.3-cp314-cp314t-win32.whl", hash = "sha256:ffe0883b56cfc05798bf994164d2b2ff03efe2d22022a2bb080f3b626176dd56", size = 1949756, upload-time = "2026-04-20T14:41:25.717Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2a/c79cf53fd91e5a87e30d481809f52f9a60dd221e39de66455cf04deaad37/pydantic_core-2.46.3-cp314-cp314t-win_amd64.whl", hash = "sha256:706d9d0ce9cf4593d07270d8e9f53b161f90c57d315aeec4fb4fd7a8b10240d8", size = 2051305, upload-time = "2026-04-20T14:43:18.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/db/d8182a7f1d9343a032265aae186eb063fe26ca4c40f256b21e8da4498e89/pydantic_core-2.46.3-cp314-cp314t-win_arm64.whl", hash = "sha256:77706aeb41df6a76568434701e0917da10692da28cb69d5fb6919ce5fdb07374", size = 2026310, upload-time = "2026-04-20T14:41:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/34/42/f426db557e8ab2791bc7562052299944a118655496fbff99914e564c0a94/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:b12dd51f1187c2eb489af8e20f880362db98e954b54ab792fa5d92e8bcc6b803", size = 2091877, upload-time = "2026-04-20T14:43:27.091Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/86a832a9d14df58e663bfdf4627dc00d3317c2bd583c4fb23390b0f04b8e/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f00a0961b125f1a47af7bcc17f00782e12f4cd056f83416006b30111d941dfa3", size = 1932428, upload-time = "2026-04-20T14:40:45.781Z" },
+    { url = "https://files.pythonhosted.org/packages/11/1a/fe857968954d93fb78e0d4b6df5c988c74c4aaa67181c60be7cfe327c0ca/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57697d7c056aca4bbb680200f96563e841a6386ac1129370a0102592f4dddff5", size = 1997550, upload-time = "2026-04-20T14:44:02.425Z" },
+    { url = "https://files.pythonhosted.org/packages/17/eb/9d89ad2d9b0ba8cd65393d434471621b98912abb10fbe1df08e480ba57b5/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd35aa21299def8db7ef4fe5c4ff862941a9a158ca7b63d61e66fe67d30416b4", size = 2137657, upload-time = "2026-04-20T14:42:45.149Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+]


### PR DESCRIPTION
## Currently

Euphony renders Harmony conversations and Codex JSONL session logs, with a dedicated `<euphony-codex>` viewer for the latter. Harbor's Agent Trajectory Interchange Format (ATIF) — a single-document JSON format that's structurally distinct from both — is not detected and falls through to the generic JSON viewer, which loses the trajectory-specific rendering (tool-call ↔ observation pairing, agent metadata, step metrics, etc.). Loading a `*.trajectory.json` from `harbor/tests/golden/...` today shows raw JSON with no conversational structure.

## Change Summary

- New `src/utils/atif-trajectory.ts`: schema types, `isAtifTrajectory` detector, `parseAtifTrajectory` (ATIF → Conversation), `serializeAtifTrajectory` round-trip, and `validateAtifTrajectory`. Steps map to one primary dialogue message plus optional reasoning, tool-call, and observation messages. Tool calls and their matching observations correlate by `function_name` (built from a per-step `tool_call_id → function_name` map) so the viewer renders the call/output pair under a single tool label.
- New `<euphony-atif>` Lit shell that mirrors `<euphony-codex>` and delegates to `<euphony-conversation>`. Read-only by design (no `is-editable` property forwarded).
- New `src/components/app/local-data-parser.ts`: extracted the inline parser out of `local-data-worker.ts` so it's unit-testable. ATIF detection runs before the Codex JSONL check.
- `src/components/app/app.ts`: `DataType.ATIF`, state field, render branch, and URL-load branch.
- Validator mirrors harbor's Pydantic constraints: sequential `step_id`, agent-only fields, ContentPart shape (text/image required fields, image `media_type` literal), tool-call ↔ observation `source_call_id` references, strict ISO-8601 timestamps, `tool_definitions` envelope shape.
- Tests: `src/utils/atif-trajectory.test.ts` (12 cases) and `src/components/app/local-data-parser.test.ts` (6 cases) — both run under vitest.

## Acceptance Criteria

- [x] `pnpm test` — vitest passes (18/18)
- [x] `pnpm build` — clean
- [x] Load a Harbor ATIF trajectory via URL (`?path=https://...`) → renders with Session/Agent/Schema/Steps chips and tool-call/output pairs sharing a label
- [x] Regular Conversation JSON still routes correctly *(verified: `examples/simple-harmony-convos.jsonl` → `dataType=conversation` → `<euphony-conversation>`)*
- [x] Codex JSONL still routes correctly *(verified: minimal `session_meta`/`event_msg`/`response_item` JSONL → `dataType=codex` → `<euphony-codex>`; ATIF detection runs first but only matches single-element arrays whose first element looks like an ATIF document)*
- [x] Round-trip integrity: `serializeAtifTrajectory(parseAtifTrajectory(x).conversation)` deep-equals `x` for all harbor goldens *(8/8 terminus_2 fixtures + 2/2 openhands `*.trajectory.json` fixtures, all v1.5/v1.6, deep-equal)*
- [x] Routing matrix: every `*.trajectory.json` in `harbor/tests/golden/{terminus_2,openhands}` routes to `DataType.ATIF` and mounts `<euphony-atif>` (10/10); both `*.traces.json` files (raw OpenHands replay events, not ATIF) correctly fall back to `DataType.JSON`
- [x] Load via "Load local file" — manually checked by me, Jordan

## Notes

- **Read-only by design.** `<euphony-atif>` does not expose `is-editable`, and `?disable-editing-mode-save-button=${true}` is set as belt-and-suspenders. `serializeAtifTrajectory` returns the originally-parsed document verbatim — it does not synthesize ATIF from edits to the in-memory Conversation, because the schema requires sequential step IDs, agent name/version, and tool-call/observation ID references that arbitrary Harmony conversations don't reliably preserve. If lossy export of edited trajectories ever becomes a requirement, build a separate writer rather than changing this one.
- **Detection ordering.** ATIF runs before Codex JSONL detection. ATIF is a single JSON document (one-element array after `JSON.parse`), so the discriminator is cheap and unambiguous (`schema_version: "ATIF-*"` + `agent.{name,version}` + non-empty `steps`). Putting it first prevents a future ATIF version with an event-shaped extra field from being misclassified as Codex.
- **Validator strictness vs. harbor.** Harbor's Pydantic types `tool_definitions` only as `list[dict[str, Any]]` but the RFC text mandates the OpenAI `{type, function}` envelope; we enforce the RFC. Image `media_type` is restricted to the four-MIME Literal harbor uses. Strict ISO-8601 timestamp regex matches `Step.validate_timestamp` in `harbor/src/harbor/models/trajectories/step.py`; the parser uses the same check so a timestamp that fails validation also yields `create_time === undefined` rather than a `Date.parse`-coerced value.