### PR TITLE
ci: declare contents:read on Build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `Build` workflow runs `corepack enable`, `pnpm install --frozen-lockfile`, `pnpm run build`, and `pnpm run build:library`. No GitHub API write beyond `actions/checkout`.

This patch pins it to `permissions: contents: read` at workflow scope, matching the per-job block in `publish.yml` (`contents: read` + `id-token: write` for trusted publishing).

With explicit scope:

- the workflow token can't be widened by a future change to the repo default
- the SLSA / OpenSSF Scorecard `Token-Permissions` check passes for this file
- third-party action exposure (`actions/setup-node`, `actions/checkout`) is bounded to read

No behavioural change.